### PR TITLE
Improving StringIdentifier

### DIFF
--- a/SpiceSharp/General/StringIdentifier.cs
+++ b/SpiceSharp/General/StringIdentifier.cs
@@ -24,7 +24,7 @@ namespace SpiceSharp
         /// <param name="id">The identifier.</param>
         /// <param name="caseSensitive">Specifies whether string identifier is case-sensitive</param>
         /// <exception cref="ArgumentNullException">id</exception>
-        public StringIdentifier(string id, bool caseSensitive = false)
+        public StringIdentifier(string id, bool caseSensitive = true)
         {
             _id = id ?? throw new ArgumentNullException(nameof(id));
             _caseSensitive = caseSensitive;
@@ -46,14 +46,7 @@ namespace SpiceSharp
         /// </returns>
         public override int GetHashCode()
         {
-            if (_caseSensitive)
-            {
-                return _id.GetHashCode();
-            }
-            else
-            {
-                return _id.ToUpper().GetHashCode();
-            }
+            return _id.ToUpper().GetHashCode();
         }
 
         /// <summary>

--- a/SpiceSharp/General/StringIdentifier.cs
+++ b/SpiceSharp/General/StringIdentifier.cs
@@ -14,13 +14,20 @@ namespace SpiceSharp
         private readonly string _id;
 
         /// <summary>
+        /// Specifies whether string identifier is case-sensitive
+        /// </summary>
+        private readonly bool _caseSensitive;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="StringIdentifier"/> class.
         /// </summary>
         /// <param name="id">The identifier.</param>
+        /// <param name="caseSensitive">Specifies whether string identifier is case-sensitive</param>
         /// <exception cref="ArgumentNullException">id</exception>
-        public StringIdentifier(string id)
+        public StringIdentifier(string id, bool caseSensitive = false)
         {
             _id = id ?? throw new ArgumentNullException(nameof(id));
+            _caseSensitive = caseSensitive;
         }
 
         /// <summary>
@@ -37,7 +44,17 @@ namespace SpiceSharp
         /// <returns>
         /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
         /// </returns>
-        public override int GetHashCode() => _id.GetHashCode();
+        public override int GetHashCode()
+        {
+            if (_caseSensitive)
+            {
+                return _id.GetHashCode();
+            }
+            else
+            {
+                return _id.ToUpper().GetHashCode();
+            }
+        }
 
         /// <summary>
         /// Clones this identifier.
@@ -47,7 +64,7 @@ namespace SpiceSharp
         /// </returns>
         public override Identifier Clone()
         {
-            return new StringIdentifier(_id);
+            return new StringIdentifier(_id, _caseSensitive);
         }
 
         /// <summary>
@@ -60,7 +77,13 @@ namespace SpiceSharp
         public override bool Equals(Identifier other)
         {
             if (other is StringIdentifier si)
-                return _id.Equals(si._id);
+            {
+                if (_caseSensitive && si._caseSensitive)
+                {
+                    return _id.Equals(si._id, StringComparison.CurrentCulture);
+                }
+                return _id.Equals(si._id, StringComparison.CurrentCultureIgnoreCase);
+            }
             return false;
         }
 
@@ -74,9 +97,15 @@ namespace SpiceSharp
         public override bool Equals(object obj)
         {
             if (obj is StringIdentifier si)
-                return _id.Equals(si._id);
+                return Equals(si);
             if (obj is string str)
-                return _id.Equals(str);
+            {
+                if (_caseSensitive)
+                {
+                    return _id.Equals(str);
+                }
+                return _id.Equals(str, StringComparison.CurrentCultureIgnoreCase);
+            }
             return false;
         }
     }

--- a/SpiceSharpTest/Circuits/ValidatorTests.cs
+++ b/SpiceSharpTest/Circuits/ValidatorTests.cs
@@ -10,15 +10,15 @@ namespace SpiceSharpTest.Validation
         [Test]
         public void When_GroundNameInvalid_Expect_Exception()
         {
-            // Verifies that CircuitException is thrown during Check when circuit has a ground node called "GND"
+            // Verifies that CircuitException is not thrown during Check when circuit has a ground node called "gnd"
             var ckt = CreateCircuit("gnd");
-            Assert.Throws<CircuitException>(() => ckt.Validate());
+            ckt.Validate();
         }
 
         [Test]
         public void When_GroundNameValid_Expect_NoException()
         {
-            // Verifies that CircuitException is not thrown during Check when circuit has a ground node called "gnd"
+            // Verifies that CircuitException is not thrown during Check when circuit has a ground node called "GND"
             var ckt = CreateCircuit("GND");
             ckt.Validate();
         }

--- a/SpiceSharpTest/Circuits/ValidatorTests.cs
+++ b/SpiceSharpTest/Circuits/ValidatorTests.cs
@@ -10,9 +10,9 @@ namespace SpiceSharpTest.Validation
         [Test]
         public void When_GroundNameInvalid_Expect_Exception()
         {
-            // Verifies that CircuitException is not thrown during Check when circuit has a ground node called "gnd"
+            // Verifies that CircuitException is thrown during Check when circuit has a ground node called "gnd"
             var ckt = CreateCircuit("gnd");
-            ckt.Validate();
+           Assert.Throws<CircuitException>( () => ckt.Validate());
         }
 
         [Test]

--- a/SpiceSharpTest/General/StringIdentifierTests.cs
+++ b/SpiceSharpTest/General/StringIdentifierTests.cs
@@ -1,0 +1,49 @@
+﻿using NUnit.Framework;
+using SpiceSharp;
+
+namespace SpiceSharpTest.General
+{
+    [TestFixture]
+    public class StringIdentifierTests
+    {
+        [Test]
+        public void When_StringIdentifier_Is_Created_From_String_Comparision_With_Strings_Test()
+        {
+            Identifier s = "abC";
+
+            Assert.AreEqual(s, "AbC");
+            Assert.AreEqual(s, "ABC");
+            Assert.AreEqual(s, "abc");
+        }
+
+        [Test]
+        public void When_StringIdentifier_Is_Created_From_String_Comparision_With_StringIdentifiers_Test()
+        {
+            Identifier s = "abC";
+
+            Assert.AreEqual(s, new StringIdentifier("abC"));
+            Assert.AreEqual(s, new StringIdentifier("ABC"));
+            Assert.AreEqual(s, new StringIdentifier("abc"));
+        }
+
+        [Test]
+        public void When_StringIdentifier_Is_Created_From_Constructor_Comparision_With_StringIdentifiers_Test()
+        {
+            Identifier s = new StringIdentifier("abC");
+
+            Assert.AreEqual(s, new StringIdentifier("abC"));
+            Assert.AreEqual(s, new StringIdentifier("ABC"));
+            Assert.AreEqual(s, new StringIdentifier("abc"));
+        }
+
+        [Test]
+        public void When_StringIdentifier_Is_Created_From_Constructor_CaseSensitive_Comparision_With_StringIdentifiers_Test()
+        {
+            Identifier s = new StringIdentifier("abC", true);
+
+            Assert.AreEqual(s, new StringIdentifier("abC", true));
+            Assert.AreNotEqual(s, new StringIdentifier("ABC", true));
+            Assert.AreNotEqual(s, new StringIdentifier("abc", true));
+        }
+    }
+}

--- a/SpiceSharpTest/General/StringIdentifierTests.cs
+++ b/SpiceSharpTest/General/StringIdentifierTests.cs
@@ -11,9 +11,9 @@ namespace SpiceSharpTest.General
         {
             Identifier s = "abC";
 
-            Assert.AreEqual(s, "AbC");
-            Assert.AreEqual(s, "ABC");
-            Assert.AreEqual(s, "abc");
+            Assert.AreEqual(s, "abC");
+            Assert.AreNotEqual(s, "ABC");
+            Assert.AreNotEqual(s, "abc");
         }
 
         [Test]
@@ -21,19 +21,19 @@ namespace SpiceSharpTest.General
         {
             Identifier s = "abC";
 
-            Assert.AreEqual(s, new StringIdentifier("abC"));
-            Assert.AreEqual(s, new StringIdentifier("ABC"));
-            Assert.AreEqual(s, new StringIdentifier("abc"));
+            Assert.AreEqual(s, new StringIdentifier("abC", false));
+            Assert.AreEqual(s, new StringIdentifier("ABC", false));
+            Assert.AreEqual(s, new StringIdentifier("abc", false));
         }
 
         [Test]
         public void When_StringIdentifier_Is_Created_From_Constructor_Comparision_With_StringIdentifiers_Test()
         {
-            Identifier s = new StringIdentifier("abC");
+            Identifier s = new StringIdentifier("abC", false);
 
-            Assert.AreEqual(s, new StringIdentifier("abC"));
-            Assert.AreEqual(s, new StringIdentifier("ABC"));
-            Assert.AreEqual(s, new StringIdentifier("abc"));
+            Assert.AreEqual(s, new StringIdentifier("abC", false));
+            Assert.AreEqual(s, new StringIdentifier("ABC", false));
+            Assert.AreEqual(s, new StringIdentifier("abc", false));
         }
 
         [Test]

--- a/SpiceSharpTest/SpiceSharpTest.csproj
+++ b/SpiceSharpTest/SpiceSharpTest.csproj
@@ -52,6 +52,7 @@
   <ItemGroup>
     <Compile Include="BasicExampleTests.cs" />
     <Compile Include="Circuits\ValidatorTests.cs" />
+    <Compile Include="General\StringIdentifierTests.cs" />
     <Compile Include="Models\Currentsources\CCCS\CurrentControlledCurrentSourceTests.cs" />
     <Compile Include="Models\Currentsources\ISRC\CurrentSourceTests.cs" />
     <Compile Include="Models\Currentsources\VCCS\VoltageControlledCurrentSourceTests.cs" />


### PR DESCRIPTION
I would like to change StringIdentifier class. Now there is a strong connection between strings and StringIdentifer (there is a implicit conversion operator). Because of that I'm unable to successfully introduce an enhanced version of StringIdentifier in the parser.

With that change I can control whether StringIdentifier is case-sensitive or not.