### PR TITLE
Proper way of exposing configuration

### DIFF
--- a/SpiceSharp/Simulations/Base/BaseSimulation.cs
+++ b/SpiceSharp/Simulations/Base/BaseSimulation.cs
@@ -21,7 +21,17 @@ namespace SpiceSharp.Simulations
         /// <value>
         /// The base configuration.
         /// </value>
-        public BaseConfiguration BaseConfiguration { get; protected set; }
+        public BaseConfiguration BaseConfiguration
+        {
+            get
+            {
+                if (Configurations.TryGet<BaseConfiguration>(out var config))
+                {
+                    return config;
+                }
+                return null;
+            }
+        }
 
         /// <summary>
         /// Gets the currently active simulation state.
@@ -105,8 +115,7 @@ namespace SpiceSharp.Simulations
                 throw new ArgumentNullException(nameof(circuit));
             base.Setup(circuit);
 
-            // Setup behaviors, configurations and states
-            BaseConfiguration = Configurations.Get<BaseConfiguration>();
+            // Setup behaviors, configurations and states            
             _temperatureBehaviors = SetupBehaviors<BaseTemperatureBehavior>(circuit.Entities);
             _loadBehaviors = SetupBehaviors<BaseLoadBehavior>(circuit.Entities);
             _initialConditionBehaviors = SetupBehaviors<BaseInitialConditionBehavior>(circuit.Entities);
@@ -197,7 +206,6 @@ namespace SpiceSharp.Simulations
             _loadBehaviors = null;
             _initialConditionBehaviors = null;
             _temperatureBehaviors = null;
-            BaseConfiguration = null;
         }
 
         /// <summary>

--- a/SpiceSharp/Simulations/Base/Frequency/FrequencySimulation.cs
+++ b/SpiceSharp/Simulations/Base/Frequency/FrequencySimulation.cs
@@ -16,7 +16,17 @@ namespace SpiceSharp.Simulations
         /// <value>
         /// The frequency configuration.
         /// </value>
-        public FrequencyConfiguration FrequencyConfiguration { get; protected set; }
+        public FrequencyConfiguration FrequencyConfiguration
+        {
+            get
+            {
+                if (Configurations.TryGet<FrequencyConfiguration>(out var config))
+                {
+                    return config;
+                }
+                return null;
+            }
+        }
 
         /// <summary>
         /// Private variables
@@ -87,8 +97,11 @@ namespace SpiceSharp.Simulations
             base.Setup(circuit);
 
             // Get behaviors, configurations and states
-            FrequencyConfiguration = Configurations.Get<FrequencyConfiguration>() ??
-                                     throw new CircuitException("No frequency configuration found");
+            if (FrequencyConfiguration == null)
+            {
+                throw new CircuitException("No frequency configuration found");
+            }
+
             FrequencySweep = FrequencyConfiguration.FrequencySweep ??
                              throw new CircuitException("No frequency sweep found");
 
@@ -133,7 +146,6 @@ namespace SpiceSharp.Simulations
             ComplexState = null;
 
             // Configuration
-            FrequencyConfiguration = null;
             FrequencySweep = null;
 
             base.Unsetup();

--- a/SpiceSharp/Simulations/Base/Time/TimeSimulation.cs
+++ b/SpiceSharp/Simulations/Base/Time/TimeSimulation.cs
@@ -12,12 +12,22 @@ namespace SpiceSharp.Simulations
     public abstract class TimeSimulation : BaseSimulation
     {
         /// <summary>
-        /// Gets the currently active time configuration.
+        /// Gets the currently time configuration.
         /// </summary>
         /// <value>
         /// The time configuration.
         /// </value>
-        public TimeConfiguration TimeConfiguration { get; protected set; }
+        public TimeConfiguration TimeConfiguration
+        {
+            get
+            {
+                if (Configurations.TryGet<TimeConfiguration>(out var config))
+                {
+                    return config;
+                }
+                return null;
+            }
+        }
 
         /// <summary>
         /// Gets the active integration method.
@@ -87,9 +97,7 @@ namespace SpiceSharp.Simulations
             base.Setup(circuit);
 
             // Get behaviors and configurations
-            var config = Configurations.Get<TimeConfiguration>() ?? throw new CircuitException("{0}: No time configuration".FormatString(Name));
-            TimeConfiguration = config;
-            Method = config.Method ?? throw new CircuitException("{0}: No integration method specified".FormatString(Name));
+            Method = TimeConfiguration?.Method ?? throw new CircuitException("{0}: No integration method specified".FormatString(Name));
             _transientBehaviors = SetupBehaviors<BaseTransientBehavior>(circuit.Entities);
 
             // Allow all transient behaviors to allocate equation elements and create states

--- a/SpiceSharp/Simulations/Implementations/DC/DC.cs
+++ b/SpiceSharp/Simulations/Implementations/DC/DC.cs
@@ -15,7 +15,17 @@ namespace SpiceSharp.Simulations
         /// <value>
         /// The dc configuration.
         /// </value>
-        public DcConfiguration DcConfiguration { get; protected set; }
+        public DcConfiguration DcConfiguration
+        {
+            get
+            {
+                if (Configurations.TryGet<DcConfiguration>(out var config))
+                {
+                    return config;
+                }
+                return null;
+            }
+        }
 
         /// <summary>
         /// Gets the currently active sweeps.
@@ -84,9 +94,6 @@ namespace SpiceSharp.Simulations
         protected override void Setup(Circuit circuit)
         {
             base.Setup(circuit);
-
-            // Get DC configuration
-            DcConfiguration = Configurations.Get<DcConfiguration>();
 
             // Get sweeps
             Sweeps = new NestedSweeps(DcConfiguration.Sweeps);
@@ -217,7 +224,6 @@ namespace SpiceSharp.Simulations
             Sweeps = null;
 
             // Clear configuration
-            DcConfiguration = null;
             base.Unsetup();
         }
     }

--- a/SpiceSharp/Simulations/Implementations/Noise/Noise.cs
+++ b/SpiceSharp/Simulations/Implementations/Noise/Noise.cs
@@ -17,7 +17,17 @@ namespace SpiceSharp.Simulations
         /// <value>
         /// The noise configuration.
         /// </value>
-        public NoiseConfiguration NoiseConfiguration { get; protected set; }
+        public NoiseConfiguration NoiseConfiguration
+        {
+            get
+            {
+                if (Configurations.TryGet<NoiseConfiguration>(out var config))
+                {
+                    return config;
+                }
+                return null;
+            }
+        }
 
         /// <summary>
         /// Gets the noise state.
@@ -78,7 +88,6 @@ namespace SpiceSharp.Simulations
             base.Setup(circuit);
 
             // Get behaviors, parameters and states
-            NoiseConfiguration = Configurations.Get<NoiseConfiguration>();
             _noiseBehaviors = SetupBehaviors<BaseNoiseBehavior>(circuit.Entities);
             NoiseState = new NoiseState();
             NoiseState.Setup(Variables);
@@ -95,7 +104,6 @@ namespace SpiceSharp.Simulations
             for (var i = 0; i < _noiseBehaviors.Count; i++)
                 _noiseBehaviors[i].Unsetup(this);
             _noiseBehaviors = null;
-            NoiseConfiguration = null;
 
             base.Unsetup();
         }


### PR DESCRIPTION
There is issue with current implementation. I'm unable to set initial conditions. The property where I can do it is set during Setup. There is no time when I could set initial conditions because the property is null.