### PR TITLE
Development

### DIFF
--- a/SpiceSharp/Circuits/Circuit.cs
+++ b/SpiceSharp/Circuits/Circuit.cs
@@ -78,13 +78,6 @@ namespace SpiceSharp
             };
         }
 
-        public void Instantiate(Circuit subcircuit, string name)
-        {
-            foreach (var entity in subcircuit.Entities)
-            {
-            }
-        }
-
         /// <summary>
         /// Clear all entities in the circuit.
         /// </summary>

--- a/SpiceSharp/Circuits/Circuit.cs
+++ b/SpiceSharp/Circuits/Circuit.cs
@@ -78,6 +78,13 @@ namespace SpiceSharp
             };
         }
 
+        public void Instantiate(Circuit subcircuit, string name)
+        {
+            foreach (var entity in subcircuit.Entities)
+            {
+            }
+        }
+
         /// <summary>
         /// Clear all entities in the circuit.
         /// </summary>

--- a/SpiceSharp/Circuits/Entity.cs
+++ b/SpiceSharp/Circuits/Entity.cs
@@ -82,7 +82,7 @@ namespace SpiceSharp.Circuits
             if (!BehaviorFactories.TryGetValue(GetType(), out var behaviors))
                 return null;
             if (behaviors.TryGetValue(type, out var behavior))
-                return behavior(Name);
+                return behavior(this);
             return null;
         }
 

--- a/SpiceSharp/Circuits/Entity.cs
+++ b/SpiceSharp/Circuits/Entity.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Reflection;
 using SpiceSharp.Behaviors;
 using SpiceSharp.Simulations;
 
@@ -12,9 +11,21 @@ namespace SpiceSharp.Circuits
     public abstract class Entity
     {
         /// <summary>
-        /// Factories for behaviors.
+        /// Factories for behaviors by type.
         /// </summary>
-        protected BehaviorFactoryDictionary Behaviors { get; } = new BehaviorFactoryDictionary();
+        private static Dictionary<Type, BehaviorFactoryDictionary> BehaviorFactories { get; } =
+            new Dictionary<Type, BehaviorFactoryDictionary>();
+
+        /// <summary>
+        /// Registers a behavior factory for an entity type.
+        /// </summary>
+        /// <param name="entityType">Type of the entity.</param>
+        /// <param name="dictionary">The dictionary.</param>
+        protected static void RegisterBehaviorFactory(Type entityType, BehaviorFactoryDictionary dictionary)
+        {
+            // We do this to avoid anyone unregistering factories!
+            BehaviorFactories.Add(entityType, dictionary);
+        }
 
         /// <summary>
         /// Gets a collection of parameters.
@@ -68,15 +79,17 @@ namespace SpiceSharp.Circuits
                 throw new ArgumentNullException(nameof(simulation));
 
             // Get the factory and generate it
-            if (Behaviors.TryGetValue(type, out var behavior))
-                return behavior();
+            if (!BehaviorFactories.TryGetValue(GetType(), out var behaviors))
+                return null;
+            if (behaviors.TryGetValue(type, out var behavior))
+                return behavior(Name);
             return null;
         }
 
         /// <summary>
         /// Sets up the behavior.
         /// </summary>
-        /// <param name="type">The type of the behavior that needs to be set up.</param>
+        /// <param name="behavior">The behavior that needs to be set up.</param>
         /// <param name="simulation">The simulation.</param>
         /// <exception cref="ArgumentNullException">simulation</exception>
         public virtual void SetupBehavior(IBehavior behavior, Simulation simulation)
@@ -119,5 +132,17 @@ namespace SpiceSharp.Circuits
         /// Gets the priority of this entity.
         /// </summary>
         public int Priority { get; protected set; } = 0;
+
+        /// <summary>
+        /// Clones the entity with a new name.
+        /// </summary>
+        /// <param name="name">The name.</param>
+        /// <returns></returns>
+        public virtual Entity Clone(string name)
+        {
+            var e = (Entity) Activator.CreateInstance(GetType(), name);
+
+            return e;
+        }
     }
 }

--- a/SpiceSharp/Circuits/EntityCollection.cs
+++ b/SpiceSharp/Circuits/EntityCollection.cs
@@ -294,8 +294,16 @@ namespace SpiceSharp.Circuits
             {
                 _lock.EnterReadLock();
 
-                foreach (var t in _ordered)
-                    yield return t;
+                if (_isOrdered)
+                {
+                    foreach (var t in _ordered)
+                        yield return t;
+                }
+                else
+                {
+                    foreach (var t in _objects.Values)
+                        yield return t;
+                }
             }
             finally
             {

--- a/SpiceSharp/Circuits/Validator.cs
+++ b/SpiceSharp/Circuits/Validator.cs
@@ -66,11 +66,11 @@ namespace SpiceSharp.Circuits
             if (unconnected.Count > 0)
             {
                 var un = new List<string>();
-                for (var i = 0; i < _nodes.Count; i++)
+                foreach (var n in _nodes)
                 {
-                    var index = _nodes[i].Index;
+                    var index = n.Index;
                     if (unconnected.Contains(index))
-                        un.Add(_nodes[i].Name);
+                        un.Add(n.Name);
                 }
                 throw new CircuitException("{0}: Floating nodes found".FormatString(string.Join(",", un)));
             }
@@ -123,19 +123,20 @@ namespace SpiceSharp.Circuits
                 foreach (var attr in attributes)
                 {
                     // Voltage driven nodes are checked for voltage loops
-                    if (attr is VoltageDriverAttribute vd)
-                        _voltageDriven.Add(new Tuple<Component, int, int>(icc, nodes[vd.Positive], nodes[vd.Negative]));
-
-                    // At least one source needs to be available
-                    if (attr is IndependentSourceAttribute)
-                        _hasSource = true;
-
-                    if (attr is ConnectedAttribute conn)
+                    switch (attr)
                     {
-                        // Add connection between pins
-                        if (conn.Pin1 >= 0 && conn.Pin2 >= 0)
-                            AddConnections(new[] { nodes[conn.Pin1], nodes[conn.Pin2] });
-                        hasconnections = true;
+                        case VoltageDriverAttribute vd:
+                            _voltageDriven.Add(new Tuple<Component, int, int>(icc, nodes[vd.Positive], nodes[vd.Negative]));
+                            break;
+                        case IndependentSourceAttribute _:
+                            _hasSource = true;
+                            break;
+                        case ConnectedAttribute conn:
+                            // Add connection between pins
+                            if (conn.Pin1 >= 0 && conn.Pin2 >= 0)
+                                AddConnections(new[] { nodes[conn.Pin1], nodes[conn.Pin2] });
+                            hasconnections = true;
+                            break;
                     }
                 }
 

--- a/SpiceSharp/Components/Currentsources/CCCS/CurrentControlledCurrentSource.cs
+++ b/SpiceSharp/Components/Currentsources/CCCS/CurrentControlledCurrentSource.cs
@@ -15,8 +15,8 @@ namespace SpiceSharp.Components
         {
             RegisterBehaviorFactory(typeof(CurrentControlledCurrentSource), new BehaviorFactoryDictionary
             {
-                {typeof(BiasingBehavior), name => new BiasingBehavior(name)},
-                {typeof(FrequencyBehavior), name => new FrequencyBehavior(name)}
+                {typeof(BiasingBehavior), e => new BiasingBehavior(e.Name)},
+                {typeof(FrequencyBehavior), e => new FrequencyBehavior(e.Name)}
             });
         }
 
@@ -39,10 +39,7 @@ namespace SpiceSharp.Components
         public CurrentControlledCurrentSource(string name) 
             : base(name, CurrentControlledCurrentSourcePinCount)
         {
-            // Make sure the current controlled current source happens after voltage sources
             Priority = ComponentPriority - 1;
-            
-            // Add parameters
             ParameterSets.Add(new BaseParameters());
         }
 
@@ -58,8 +55,6 @@ namespace SpiceSharp.Components
             : this(name)
         {
             ParameterSets.Get<BaseParameters>().Coefficient.Value = gain;
-            
-            // Connect
             Connect(pos, neg);
             ControllingName = voltageSource;
         }

--- a/SpiceSharp/Components/Currentsources/CCCS/CurrentControlledCurrentSource.cs
+++ b/SpiceSharp/Components/Currentsources/CCCS/CurrentControlledCurrentSource.cs
@@ -11,6 +11,15 @@ namespace SpiceSharp.Components
     [Pin(0, "F+"), Pin(1, "F-"), Connected(0, 0)]
     public class CurrentControlledCurrentSource : Component
     {
+        static CurrentControlledCurrentSource()
+        {
+            RegisterBehaviorFactory(typeof(CurrentControlledCurrentSource), new BehaviorFactoryDictionary
+            {
+                {typeof(BiasingBehavior), name => new BiasingBehavior(name)},
+                {typeof(FrequencyBehavior), name => new FrequencyBehavior(name)}
+            });
+        }
+
         /// <summary>
         /// Parameters
         /// </summary>
@@ -35,10 +44,6 @@ namespace SpiceSharp.Components
             
             // Add parameters
             ParameterSets.Add(new BaseParameters());
-
-            // Add behaviors
-            Behaviors.Add(typeof(BiasingBehavior), () => new BiasingBehavior(Name));
-            Behaviors.Add(typeof(FrequencyBehavior), () => new FrequencyBehavior(Name));
         }
 
         /// <summary>

--- a/SpiceSharp/Components/Currentsources/ISRC/CurrentSource.cs
+++ b/SpiceSharp/Components/Currentsources/ISRC/CurrentSource.cs
@@ -1,4 +1,5 @@
 ﻿using SpiceSharp.Attributes;
+using SpiceSharp.Behaviors;
 using SpiceSharp.Components.CurrentSourceBehaviors;
 
 namespace SpiceSharp.Components
@@ -9,6 +10,16 @@ namespace SpiceSharp.Components
     [Pin(0, "I+"), Pin(1, "I-"), IndependentSource, Connected]
     public class CurrentSource : Component
     {
+        static CurrentSource()
+        {
+            RegisterBehaviorFactory(typeof(CurrentSource), new BehaviorFactoryDictionary
+            {
+                {typeof(BiasingBehavior), n => new BiasingBehavior(n)},
+                {typeof(FrequencyBehavior), n => new FrequencyBehavior(n)},
+                {typeof(AcceptBehavior), n => new AcceptBehavior(n)}
+            });
+        }
+
         /// <summary>
         /// Constants
         /// </summary>
@@ -25,11 +36,6 @@ namespace SpiceSharp.Components
             // Add parameters
             ParameterSets.Add(new CommonBehaviors.IndependentBaseParameters());
             ParameterSets.Add(new CommonBehaviors.IndependentFrequencyParameters());
-
-            // Add factories
-            Behaviors.Add(typeof(BiasingBehavior), () => new BiasingBehavior(Name));
-            Behaviors.Add(typeof(FrequencyBehavior), () => new FrequencyBehavior(Name));
-            Behaviors.Add(typeof(AcceptBehavior), () => new AcceptBehavior(Name));
         }
 
         /// <summary>
@@ -40,16 +46,11 @@ namespace SpiceSharp.Components
         /// <param name="neg">The negative node</param>
         /// <param name="dc">The DC value</param>
         public CurrentSource(string name, string pos, string neg, double dc)
-            : base(name, CurrentSourcePinCount)
+            : this(name)
         {
             // Add parameters
             ParameterSets.Add(new CommonBehaviors.IndependentBaseParameters(dc));
             ParameterSets.Add(new CommonBehaviors.IndependentFrequencyParameters());
-
-            // Add factories
-            Behaviors.Add(typeof(BiasingBehavior), () => new BiasingBehavior(Name));
-            Behaviors.Add(typeof(FrequencyBehavior), () => new FrequencyBehavior(Name));
-            Behaviors.Add(typeof(AcceptBehavior), () => new AcceptBehavior(Name));
 
             // Connect
             Connect(pos, neg);
@@ -63,16 +64,11 @@ namespace SpiceSharp.Components
         /// <param name="neg">The negative node</param>
         /// <param name="waveform">The Waveform-object</param>
         public CurrentSource(string name, string pos, string neg, Waveform waveform)
-            : base(name, CurrentSourcePinCount)
+            : this(name)
         {
             // Add parameters
             ParameterSets.Add(new CommonBehaviors.IndependentBaseParameters(waveform));
             ParameterSets.Add(new CommonBehaviors.IndependentFrequencyParameters());
-
-            // Add factories
-            Behaviors.Add(typeof(BiasingBehavior), () => new BiasingBehavior(Name));
-            Behaviors.Add(typeof(FrequencyBehavior), () => new FrequencyBehavior(Name));
-            Behaviors.Add(typeof(AcceptBehavior), () => new AcceptBehavior(Name));
 
             // Connect
             Connect(pos, neg);

--- a/SpiceSharp/Components/Currentsources/ISRC/CurrentSource.cs
+++ b/SpiceSharp/Components/Currentsources/ISRC/CurrentSource.cs
@@ -14,9 +14,9 @@ namespace SpiceSharp.Components
         {
             RegisterBehaviorFactory(typeof(CurrentSource), new BehaviorFactoryDictionary
             {
-                {typeof(BiasingBehavior), n => new BiasingBehavior(n)},
-                {typeof(FrequencyBehavior), n => new FrequencyBehavior(n)},
-                {typeof(AcceptBehavior), n => new AcceptBehavior(n)}
+                {typeof(BiasingBehavior), e => new BiasingBehavior(e.Name)},
+                {typeof(FrequencyBehavior), e => new FrequencyBehavior(e.Name)},
+                {typeof(AcceptBehavior), e => new AcceptBehavior(e.Name)}
             });
         }
 
@@ -33,7 +33,6 @@ namespace SpiceSharp.Components
         public CurrentSource(string name) 
             : base(name, CurrentSourcePinCount)
         {
-            // Add parameters
             ParameterSets.Add(new CommonBehaviors.IndependentBaseParameters());
             ParameterSets.Add(new CommonBehaviors.IndependentFrequencyParameters());
         }
@@ -48,11 +47,8 @@ namespace SpiceSharp.Components
         public CurrentSource(string name, string pos, string neg, double dc)
             : this(name)
         {
-            // Add parameters
             ParameterSets.Add(new CommonBehaviors.IndependentBaseParameters(dc));
             ParameterSets.Add(new CommonBehaviors.IndependentFrequencyParameters());
-
-            // Connect
             Connect(pos, neg);
         }
 
@@ -66,11 +62,8 @@ namespace SpiceSharp.Components
         public CurrentSource(string name, string pos, string neg, Waveform waveform)
             : this(name)
         {
-            // Add parameters
             ParameterSets.Add(new CommonBehaviors.IndependentBaseParameters(waveform));
             ParameterSets.Add(new CommonBehaviors.IndependentFrequencyParameters());
-
-            // Connect
             Connect(pos, neg);
         }
     }

--- a/SpiceSharp/Components/Currentsources/VCCS/VoltageControlledCurrentSource.cs
+++ b/SpiceSharp/Components/Currentsources/VCCS/VoltageControlledCurrentSource.cs
@@ -14,8 +14,8 @@ namespace SpiceSharp.Components
         {
             RegisterBehaviorFactory(typeof(VoltageControlledCurrentSource), new BehaviorFactoryDictionary
             {
-                {typeof(BiasingBehavior), n => new BiasingBehavior(n)},
-                {typeof(FrequencyBehavior), n => new FrequencyBehavior(n)}
+                {typeof(BiasingBehavior), e => new BiasingBehavior(e.Name)},
+                {typeof(FrequencyBehavior), e => new FrequencyBehavior(e.Name)}
             });
         }
 
@@ -32,7 +32,6 @@ namespace SpiceSharp.Components
         public VoltageControlledCurrentSource(string name)
             : base(name, VoltageControlledCurrentSourcePinCount)
         {
-            // Add parameters
             ParameterSets.Add(new BaseParameters());
         }
 
@@ -48,10 +47,7 @@ namespace SpiceSharp.Components
         public VoltageControlledCurrentSource(string name, string pos, string neg, string controlPos, string controlNeg, double gain)
             : this(name)
         {
-            // Add parameters
             ParameterSets.Add(new BaseParameters(gain));
-
-            // Connect
             Connect(pos, neg, controlPos, controlNeg);
         }
     }

--- a/SpiceSharp/Components/Currentsources/VCCS/VoltageControlledCurrentSource.cs
+++ b/SpiceSharp/Components/Currentsources/VCCS/VoltageControlledCurrentSource.cs
@@ -1,4 +1,5 @@
 ﻿using SpiceSharp.Attributes;
+using SpiceSharp.Behaviors;
 using SpiceSharp.Components.VoltageControlledCurrentSourceBehaviors;
 
 namespace SpiceSharp.Components
@@ -9,6 +10,15 @@ namespace SpiceSharp.Components
     [Pin(0, "V+"), Pin(1, "V-"), Pin(2, "VC+"), Pin(3, "VC-"), Connected(0, 1)]
     public class VoltageControlledCurrentSource : Component
     {
+        static VoltageControlledCurrentSource()
+        {
+            RegisterBehaviorFactory(typeof(VoltageControlledCurrentSource), new BehaviorFactoryDictionary
+            {
+                {typeof(BiasingBehavior), n => new BiasingBehavior(n)},
+                {typeof(FrequencyBehavior), n => new FrequencyBehavior(n)}
+            });
+        }
+
         /// <summary>
         /// Private constants
         /// </summary>
@@ -24,10 +34,6 @@ namespace SpiceSharp.Components
         {
             // Add parameters
             ParameterSets.Add(new BaseParameters());
-
-            // Add factories
-            Behaviors.Add(typeof(BiasingBehavior), () => new BiasingBehavior(Name));
-            Behaviors.Add(typeof(FrequencyBehavior), () => new FrequencyBehavior(Name));
         }
 
         /// <summary>
@@ -40,14 +46,10 @@ namespace SpiceSharp.Components
         /// <param name="controlNeg">The negative controlling node</param>
         /// <param name="gain">The transconductance gain</param>
         public VoltageControlledCurrentSource(string name, string pos, string neg, string controlPos, string controlNeg, double gain)
-            : base(name, VoltageControlledCurrentSourcePinCount)
+            : this(name)
         {
             // Add parameters
             ParameterSets.Add(new BaseParameters(gain));
-
-            // Add factories
-            Behaviors.Add(typeof(BiasingBehavior), () => new BiasingBehavior(Name));
-            Behaviors.Add(typeof(FrequencyBehavior), () => new FrequencyBehavior(Name));
 
             // Connect
             Connect(pos, neg, controlPos, controlNeg);

--- a/SpiceSharp/Components/Distributed/LoslessTransmissionLine/LosslessTransmissionLine.cs
+++ b/SpiceSharp/Components/Distributed/LoslessTransmissionLine/LosslessTransmissionLine.cs
@@ -15,10 +15,10 @@ namespace SpiceSharp.Components
         {
             RegisterBehaviorFactory(typeof(LosslessTransmissionLine), new BehaviorFactoryDictionary
             {
-                {typeof(BiasingBehavior), n => new BiasingBehavior(n)},
-                {typeof(FrequencyBehavior), n => new FrequencyBehavior(n)},
-                {typeof(TransientBehavior), n => new TransientBehavior(n)},
-                {typeof(AcceptBehavior), n => new AcceptBehavior(n)}
+                {typeof(BiasingBehavior), e => new BiasingBehavior(e.Name)},
+                {typeof(FrequencyBehavior), e => new FrequencyBehavior(e.Name)},
+                {typeof(TransientBehavior), e => new TransientBehavior(e.Name)},
+                {typeof(AcceptBehavior), e => new AcceptBehavior(e.Name)}
             });
         }
         
@@ -34,7 +34,6 @@ namespace SpiceSharp.Components
         public LosslessTransmissionLine(string name)
             : base(name, LosslessTransmissionLinePinCount)
         {
-            // Add parameters
             ParameterSets.Add(new BaseParameters());
         }
 
@@ -66,7 +65,6 @@ namespace SpiceSharp.Components
             : this(name)
         {
             Connect(pos1, neg1, pos2, neg2);
-
             var bp = ParameterSets.Get<BaseParameters>();
             bp.Impedance = impedance;
             bp.Delay.Value = delay;

--- a/SpiceSharp/Components/Distributed/LoslessTransmissionLine/LosslessTransmissionLine.cs
+++ b/SpiceSharp/Components/Distributed/LoslessTransmissionLine/LosslessTransmissionLine.cs
@@ -1,4 +1,5 @@
 ﻿using SpiceSharp.Attributes;
+using SpiceSharp.Behaviors;
 using SpiceSharp.Components.LosslessTransmissionLineBehaviors;
 
 namespace SpiceSharp.Components
@@ -10,6 +11,17 @@ namespace SpiceSharp.Components
     [Pin(0, "Pos1"), Pin(1, "Neg1"), Pin(2, "Pos2"), Pin(3, "Neg2"), Connected(0, 1), Connected(2, 3)]
     public class LosslessTransmissionLine : Component
     {
+        static LosslessTransmissionLine()
+        {
+            RegisterBehaviorFactory(typeof(LosslessTransmissionLine), new BehaviorFactoryDictionary
+            {
+                {typeof(BiasingBehavior), n => new BiasingBehavior(n)},
+                {typeof(FrequencyBehavior), n => new FrequencyBehavior(n)},
+                {typeof(TransientBehavior), n => new TransientBehavior(n)},
+                {typeof(AcceptBehavior), n => new AcceptBehavior(n)}
+            });
+        }
+        
         /// <summary>
         /// The number of pins for a lossless transmission line
         /// </summary>
@@ -24,12 +36,6 @@ namespace SpiceSharp.Components
         {
             // Add parameters
             ParameterSets.Add(new BaseParameters());
-
-            // Add behavior factories
-            Behaviors.Add(typeof(BiasingBehavior), () => new BiasingBehavior(Name));
-            Behaviors.Add(typeof(FrequencyBehavior), () => new FrequencyBehavior(Name));
-            Behaviors.Add(typeof(TransientBehavior), () => new TransientBehavior(Name));
-            Behaviors.Add(typeof(AcceptBehavior), () => new AcceptBehavior(Name));
         }
 
         /// <summary>

--- a/SpiceSharp/Components/Distributed/VoltageDelay/VoltageDelay.cs
+++ b/SpiceSharp/Components/Distributed/VoltageDelay/VoltageDelay.cs
@@ -15,16 +15,17 @@ namespace SpiceSharp.Components
         {
             RegisterBehaviorFactory(typeof(VoltageDelay), new BehaviorFactoryDictionary
             {
-                {typeof(BiasingBehavior), n => new BiasingBehavior(n)},
-                {typeof(FrequencyBehavior), n => new FrequencyBehavior(n)},
-                {typeof(TransientBehavior), n => new TransientBehavior(n)},
-                {typeof(AcceptBehavior), n => new AcceptBehavior(n)}
+                {typeof(BiasingBehavior), e => new BiasingBehavior(e.Name)},
+                {typeof(FrequencyBehavior), e => new FrequencyBehavior(e.Name)},
+                {typeof(TransientBehavior), e => new TransientBehavior(e.Name)},
+                {typeof(AcceptBehavior), e => new AcceptBehavior(e.Name)}
             });
         }
 
         /// <summary>
         /// The voltage delay pin count
         /// </summary>
+        [ParameterName("pincount"), ParameterInfo("Number of pins")]
         private const int VoltageDelayPinCount = 4;
 
         /// <summary>
@@ -34,7 +35,6 @@ namespace SpiceSharp.Components
         public VoltageDelay(string name)
             : base(name, VoltageDelayPinCount)
         {
-            // Add parameters
             ParameterSets.Add(new BaseParameters());
         }
 

--- a/SpiceSharp/Components/Distributed/VoltageDelay/VoltageDelay.cs
+++ b/SpiceSharp/Components/Distributed/VoltageDelay/VoltageDelay.cs
@@ -1,4 +1,5 @@
 ﻿using SpiceSharp.Attributes;
+using SpiceSharp.Behaviors;
 using SpiceSharp.Components.DelayBehaviors;
 
 namespace SpiceSharp.Components
@@ -10,6 +11,20 @@ namespace SpiceSharp.Components
     [Pin(0, "V+"), Pin(1, "V-"), Pin(2, "VC+"), Pin(3, "VC-"), VoltageDriver(0, 1)]
     public class VoltageDelay : Component
     {
+        static VoltageDelay()
+        {
+            RegisterBehaviorFactory(typeof(VoltageDelay), new BehaviorFactoryDictionary
+            {
+                {typeof(BiasingBehavior), n => new BiasingBehavior(n)},
+                {typeof(FrequencyBehavior), n => new FrequencyBehavior(n)},
+                {typeof(TransientBehavior), n => new TransientBehavior(n)},
+                {typeof(AcceptBehavior), n => new AcceptBehavior(n)}
+            });
+        }
+
+        /// <summary>
+        /// The voltage delay pin count
+        /// </summary>
         private const int VoltageDelayPinCount = 4;
 
         /// <summary>
@@ -21,12 +36,6 @@ namespace SpiceSharp.Components
         {
             // Add parameters
             ParameterSets.Add(new BaseParameters());
-
-            // Add behaviors
-            Behaviors.Add(typeof(BiasingBehavior), () => new BiasingBehavior(Name));
-            Behaviors.Add(typeof(FrequencyBehavior), () => new FrequencyBehavior(Name));
-            Behaviors.Add(typeof(TransientBehavior), () => new TransientBehavior(Name));
-            Behaviors.Add(typeof(AcceptBehavior), () => new AcceptBehavior(Name));
         }
 
         /// <summary>

--- a/SpiceSharp/Components/RLC/CAP/Capacitor.cs
+++ b/SpiceSharp/Components/RLC/CAP/Capacitor.cs
@@ -1,4 +1,5 @@
 ﻿using SpiceSharp.Attributes;
+using SpiceSharp.Behaviors;
 using SpiceSharp.Components.CapacitorBehaviors;
 
 namespace SpiceSharp.Components
@@ -9,6 +10,16 @@ namespace SpiceSharp.Components
     [Pin(0, "C+"), Pin(1, "C-"), Connected]
     public class Capacitor : Component
     {
+        static Capacitor()
+        {
+            RegisterBehaviorFactory(typeof(Capacitor), new BehaviorFactoryDictionary
+            {
+                {typeof(TransientBehavior), n => new TransientBehavior(n)},
+                {typeof(FrequencyBehavior), n => new FrequencyBehavior(n)},
+                {typeof(TemperatureBehavior), n => new TemperatureBehavior(n)}
+            });
+        }
+
         /// <summary>
         /// Set the model for the capacitor
         /// </summary>
@@ -29,11 +40,6 @@ namespace SpiceSharp.Components
         {
             // Register parameters
             ParameterSets.Add(new BaseParameters());
-
-            // Register factories
-            Behaviors.Add(typeof(TransientBehavior), () => new TransientBehavior(Name));
-            Behaviors.Add(typeof(FrequencyBehavior), () => new FrequencyBehavior(Name));
-            Behaviors.Add(typeof(TemperatureBehavior), () => new TemperatureBehavior(Name));
         }
 
         /// <summary>
@@ -48,11 +54,6 @@ namespace SpiceSharp.Components
         {
             // Register parameters
             ParameterSets.Add(new BaseParameters(cap));
-
-            // Register factories
-            Behaviors.Add(typeof(TransientBehavior), () => new TransientBehavior(Name));
-            Behaviors.Add(typeof(FrequencyBehavior), () => new FrequencyBehavior(Name));
-            Behaviors.Add(typeof(TemperatureBehavior), () => new TemperatureBehavior(Name));
 
             // Connect
             Connect(pos, neg);

--- a/SpiceSharp/Components/RLC/CAP/Capacitor.cs
+++ b/SpiceSharp/Components/RLC/CAP/Capacitor.cs
@@ -14,9 +14,9 @@ namespace SpiceSharp.Components
         {
             RegisterBehaviorFactory(typeof(Capacitor), new BehaviorFactoryDictionary
             {
-                {typeof(TransientBehavior), n => new TransientBehavior(n)},
-                {typeof(FrequencyBehavior), n => new FrequencyBehavior(n)},
-                {typeof(TemperatureBehavior), n => new TemperatureBehavior(n)}
+                {typeof(TransientBehavior), e => new TransientBehavior(e.Name)},
+                {typeof(FrequencyBehavior), e => new FrequencyBehavior(e.Name)},
+                {typeof(TemperatureBehavior), e => new TemperatureBehavior(e.Name)}
             });
         }
 
@@ -38,7 +38,6 @@ namespace SpiceSharp.Components
         /// <param name="name"></param>
         public Capacitor(string name) : base(name, CapacitorPinCount)
         {
-            // Register parameters
             ParameterSets.Add(new BaseParameters());
         }
 
@@ -52,10 +51,7 @@ namespace SpiceSharp.Components
         public Capacitor(string name, string pos, string neg, double cap) 
             : base(name, CapacitorPinCount)
         {
-            // Register parameters
             ParameterSets.Add(new BaseParameters(cap));
-
-            // Connect
             Connect(pos, neg);
         }
     }

--- a/SpiceSharp/Components/RLC/CAP/CapacitorModel.cs
+++ b/SpiceSharp/Components/RLC/CAP/CapacitorModel.cs
@@ -13,7 +13,6 @@ namespace SpiceSharp.Components
         /// <param name="name"></param>
         public CapacitorModel(string name) : base(name)
         {
-            // Register parameters
             ParameterSets.Add(new ModelBaseParameters());
         }
     }

--- a/SpiceSharp/Components/RLC/IND/Inductor.cs
+++ b/SpiceSharp/Components/RLC/IND/Inductor.cs
@@ -14,9 +14,9 @@ namespace SpiceSharp.Components
         {
             RegisterBehaviorFactory(typeof(Inductor), new BehaviorFactoryDictionary
             {
-                {typeof(BiasingBehavior), name => new BiasingBehavior(name)},
-                {typeof(TransientBehavior), name => new TransientBehavior(name)},
-                {typeof(FrequencyBehavior), name => new FrequencyBehavior(name)}
+                {typeof(BiasingBehavior), e => new BiasingBehavior(e.Name)},
+                {typeof(TransientBehavior), e => new TransientBehavior(e.Name)},
+                {typeof(FrequencyBehavior), e => new FrequencyBehavior(e.Name)}
             });
         }
 
@@ -33,7 +33,6 @@ namespace SpiceSharp.Components
         public Inductor(string name)
             : base(name, InductorPinCount)
         {
-            // Add parameters
             ParameterSets.Add(new BaseParameters());
         }
 
@@ -47,10 +46,7 @@ namespace SpiceSharp.Components
         public Inductor(string name, string pos, string neg, double inductance) 
             : base(name, InductorPinCount)
         {
-            // Add parameters
             ParameterSets.Add(new BaseParameters(inductance));
-
-            // Connect
             Connect(pos, neg);
         }
     }

--- a/SpiceSharp/Components/RLC/IND/Inductor.cs
+++ b/SpiceSharp/Components/RLC/IND/Inductor.cs
@@ -1,4 +1,5 @@
 ﻿using SpiceSharp.Attributes;
+using SpiceSharp.Behaviors;
 using SpiceSharp.Components.InductorBehaviors;
 
 namespace SpiceSharp.Components
@@ -9,6 +10,16 @@ namespace SpiceSharp.Components
     [Pin(0, "L+"), Pin(1, "L-")]
     public class Inductor : Component
     {
+        static Inductor()
+        {
+            RegisterBehaviorFactory(typeof(Inductor), new BehaviorFactoryDictionary
+            {
+                {typeof(BiasingBehavior), name => new BiasingBehavior(name)},
+                {typeof(TransientBehavior), name => new TransientBehavior(name)},
+                {typeof(FrequencyBehavior), name => new FrequencyBehavior(name)}
+            });
+        }
+
         /// <summary>
         /// Constants
         /// </summary>
@@ -24,11 +35,6 @@ namespace SpiceSharp.Components
         {
             // Add parameters
             ParameterSets.Add(new BaseParameters());
-
-            // Add factories
-            Behaviors.Add(typeof(BiasingBehavior), () => new BiasingBehavior(Name));
-            Behaviors.Add(typeof(TransientBehavior), () => new TransientBehavior(Name));
-            Behaviors.Add(typeof(FrequencyBehavior), () => new FrequencyBehavior(Name));
         }
 
         /// <summary>
@@ -43,11 +49,6 @@ namespace SpiceSharp.Components
         {
             // Add parameters
             ParameterSets.Add(new BaseParameters(inductance));
-
-            // Add factories
-            Behaviors.Add(typeof(BiasingBehavior), () => new BiasingBehavior(Name));
-            Behaviors.Add(typeof(TransientBehavior), () => new TransientBehavior(Name));
-            Behaviors.Add(typeof(FrequencyBehavior), () => new FrequencyBehavior(Name));
 
             // Connect
             Connect(pos, neg);

--- a/SpiceSharp/Components/RLC/MUT/MutualInductance.cs
+++ b/SpiceSharp/Components/RLC/MUT/MutualInductance.cs
@@ -10,6 +10,16 @@ namespace SpiceSharp.Components
     /// </summary>
     public class MutualInductance : Component
     {
+        static MutualInductance()
+        {
+            RegisterBehaviorFactory(typeof(MutualInductance), new BehaviorFactoryDictionary
+            {
+
+                {typeof(TransientBehavior), name => new TransientBehavior(name)},
+                {typeof(FrequencyBehavior), name => new FrequencyBehavior(name)}
+            });
+        }
+
         /// <summary>
         /// Parameters
         /// </summary>
@@ -29,10 +39,6 @@ namespace SpiceSharp.Components
 
             // Add parameters
             ParameterSets.Add(new BaseParameters());
-
-            // Add factories
-            Behaviors.Add(typeof(TransientBehavior), () => new TransientBehavior(Name));
-            Behaviors.Add(typeof(FrequencyBehavior), () => new FrequencyBehavior(Name));
         }
 
         /// <summary>
@@ -50,10 +56,6 @@ namespace SpiceSharp.Components
 
             // Add parameters
             ParameterSets.Add(new BaseParameters(coupling));
-
-            // Add factories
-            Behaviors.Add(typeof(TransientBehavior), () => new TransientBehavior(Name));
-            Behaviors.Add(typeof(FrequencyBehavior), () => new FrequencyBehavior(Name));
 
             // Connect
             InductorName1 = inductorName1;

--- a/SpiceSharp/Components/RLC/MUT/MutualInductance.cs
+++ b/SpiceSharp/Components/RLC/MUT/MutualInductance.cs
@@ -14,9 +14,8 @@ namespace SpiceSharp.Components
         {
             RegisterBehaviorFactory(typeof(MutualInductance), new BehaviorFactoryDictionary
             {
-
-                {typeof(TransientBehavior), name => new TransientBehavior(name)},
-                {typeof(FrequencyBehavior), name => new FrequencyBehavior(name)}
+                {typeof(TransientBehavior), e => new TransientBehavior(e.Name)},
+                {typeof(FrequencyBehavior), e => new FrequencyBehavior(e.Name)}
             });
         }
 
@@ -34,10 +33,7 @@ namespace SpiceSharp.Components
         /// <param name="name">The name of the mutual inductance</param>
         public MutualInductance(string name) : base(name, 0)
         {
-            // Make sure mutual inductances are evaluated AFTER inductors
             Priority = ComponentPriority - 1;
-
-            // Add parameters
             ParameterSets.Add(new BaseParameters());
         }
 
@@ -51,13 +47,8 @@ namespace SpiceSharp.Components
         public MutualInductance(string name, string inductorName1, string inductorName2, double coupling)
             : base(name, 0)
         {
-            // Make sure mutual inductances are evaluated AFTER inductors
             Priority = ComponentPriority - 1;
-
-            // Add parameters
             ParameterSets.Add(new BaseParameters(coupling));
-
-            // Connect
             InductorName1 = inductorName1;
             InductorName2 = inductorName2;
         }

--- a/SpiceSharp/Components/RLC/RES/Resistor.cs
+++ b/SpiceSharp/Components/RLC/RES/Resistor.cs
@@ -1,4 +1,5 @@
 ﻿using SpiceSharp.Attributes;
+using SpiceSharp.Behaviors;
 using SpiceSharp.Components.ResistorBehaviors;
 
 namespace SpiceSharp.Components
@@ -9,6 +10,17 @@ namespace SpiceSharp.Components
     [Pin(0, "R+"), Pin(1, "R-")]
     public class Resistor : Component
     {
+        static Resistor()
+        {
+            RegisterBehaviorFactory(typeof(Resistor), new BehaviorFactoryDictionary
+            {
+                {typeof(BiasingBehavior), name => new BiasingBehavior(name)},
+                {typeof(FrequencyBehavior), name => new FrequencyBehavior(name)},
+                {typeof(NoiseBehavior), name => new NoiseBehavior(name)},
+                {typeof(TemperatureBehavior), name => new TemperatureBehavior(name)}
+            });
+        }
+
         /// <summary>
         /// Set the model for the resistor
         /// </summary>
@@ -30,12 +42,6 @@ namespace SpiceSharp.Components
         {
             // Register parameters
             ParameterSets.Add(new BaseParameters());
-
-            // Register factories
-            Behaviors.Add(typeof(BiasingBehavior), () => new BiasingBehavior(Name));
-            Behaviors.Add(typeof(FrequencyBehavior), () => new FrequencyBehavior(Name));
-            Behaviors.Add(typeof(NoiseBehavior), () => new NoiseBehavior(Name));
-            Behaviors.Add(typeof(TemperatureBehavior), () => new TemperatureBehavior(Name));
         }
 
         /// <summary>
@@ -50,12 +56,6 @@ namespace SpiceSharp.Components
         {
             // Register parameters
             ParameterSets.Add(new BaseParameters(res));
-
-            // Register factories
-            Behaviors.Add(typeof(BiasingBehavior), () => new BiasingBehavior(Name));
-            Behaviors.Add(typeof(FrequencyBehavior), () => new FrequencyBehavior(Name));
-            Behaviors.Add(typeof(NoiseBehavior), () => new NoiseBehavior(Name));
-            Behaviors.Add(typeof(TemperatureBehavior), () => new TemperatureBehavior(Name));
 
             // Connect
             Connect(pos, neg);

--- a/SpiceSharp/Components/RLC/RES/Resistor.cs
+++ b/SpiceSharp/Components/RLC/RES/Resistor.cs
@@ -14,10 +14,10 @@ namespace SpiceSharp.Components
         {
             RegisterBehaviorFactory(typeof(Resistor), new BehaviorFactoryDictionary
             {
-                {typeof(BiasingBehavior), name => new BiasingBehavior(name)},
-                {typeof(FrequencyBehavior), name => new FrequencyBehavior(name)},
-                {typeof(NoiseBehavior), name => new NoiseBehavior(name)},
-                {typeof(TemperatureBehavior), name => new TemperatureBehavior(name)}
+                {typeof(BiasingBehavior), e => new BiasingBehavior(e.Name)},
+                {typeof(FrequencyBehavior), e => new FrequencyBehavior(e.Name)},
+                {typeof(NoiseBehavior), e => new NoiseBehavior(e.Name)},
+                {typeof(TemperatureBehavior), e => new TemperatureBehavior(e.Name)}
             });
         }
 
@@ -40,7 +40,6 @@ namespace SpiceSharp.Components
         public Resistor(string name) 
             : base(name, ResistorPinCount)
         {
-            // Register parameters
             ParameterSets.Add(new BaseParameters());
         }
 
@@ -54,10 +53,7 @@ namespace SpiceSharp.Components
         public Resistor(string name, string pos, string neg, double res) 
             : base(name, ResistorPinCount)
         {
-            // Register parameters
             ParameterSets.Add(new BaseParameters(res));
-
-            // Connect
             Connect(pos, neg);
         }
     }

--- a/SpiceSharp/Components/Semiconductors/Bipolar/BipolarJunctionTransistor.cs
+++ b/SpiceSharp/Components/Semiconductors/Bipolar/BipolarJunctionTransistor.cs
@@ -14,11 +14,11 @@ namespace SpiceSharp.Components
         {
             RegisterBehaviorFactory(typeof(BipolarJunctionTransistor), new BehaviorFactoryDictionary
             {
-                {typeof(TemperatureBehavior), name => new TemperatureBehavior(name)},
-                {typeof(BiasingBehavior), name => new BiasingBehavior(name)},
-                {typeof(TransientBehavior), name => new TransientBehavior(name)},
-                {typeof(FrequencyBehavior), name => new FrequencyBehavior(name)},
-                {typeof(NoiseBehavior), name => new NoiseBehavior(name)}
+                {typeof(TemperatureBehavior), e => new TemperatureBehavior(e.Name)},
+                {typeof(BiasingBehavior), e => new BiasingBehavior(e.Name)},
+                {typeof(TransientBehavior), e => new TransientBehavior(e.Name)},
+                {typeof(FrequencyBehavior), e => new FrequencyBehavior(e.Name)},
+                {typeof(NoiseBehavior), e => new NoiseBehavior(e.Name)}
             });
         }
 
@@ -40,7 +40,6 @@ namespace SpiceSharp.Components
         public BipolarJunctionTransistor(string name) 
             : base(name, BipolarJunctionTransistorPinCount)
         {
-            // Add parameters
             ParameterSets.Add(new BaseParameters());
         }
 

--- a/SpiceSharp/Components/Semiconductors/Bipolar/BipolarJunctionTransistor.cs
+++ b/SpiceSharp/Components/Semiconductors/Bipolar/BipolarJunctionTransistor.cs
@@ -1,4 +1,5 @@
 ﻿using SpiceSharp.Attributes;
+using SpiceSharp.Behaviors;
 using SpiceSharp.Components.BipolarBehaviors;
 
 namespace SpiceSharp.Components
@@ -9,6 +10,18 @@ namespace SpiceSharp.Components
     [Pin(0, "Collector"), Pin(1, "Base"), Pin(2, "Emitter"), Pin(3, "Substrate")]
     public class BipolarJunctionTransistor : Component
     {
+        static BipolarJunctionTransistor()
+        {
+            RegisterBehaviorFactory(typeof(BipolarJunctionTransistor), new BehaviorFactoryDictionary
+            {
+                {typeof(TemperatureBehavior), name => new TemperatureBehavior(name)},
+                {typeof(BiasingBehavior), name => new BiasingBehavior(name)},
+                {typeof(TransientBehavior), name => new TransientBehavior(name)},
+                {typeof(FrequencyBehavior), name => new FrequencyBehavior(name)},
+                {typeof(NoiseBehavior), name => new NoiseBehavior(name)}
+            });
+        }
+
         /// <summary>
         /// Set the model for the BJT
         /// </summary>
@@ -29,13 +42,6 @@ namespace SpiceSharp.Components
         {
             // Add parameters
             ParameterSets.Add(new BaseParameters());
-
-            // Add factories
-            Behaviors.Add(typeof(TemperatureBehavior), () => new TemperatureBehavior(Name));
-            Behaviors.Add(typeof(BiasingBehavior), () => new BiasingBehavior(Name));
-            Behaviors.Add(typeof(TransientBehavior), () => new TransientBehavior(Name));
-            Behaviors.Add(typeof(FrequencyBehavior), () => new FrequencyBehavior(Name));
-            Behaviors.Add(typeof(NoiseBehavior), () => new NoiseBehavior(Name));
         }
 
         /// <summary>

--- a/SpiceSharp/Components/Semiconductors/Bipolar/BipolarJunctionTransistorModel.cs
+++ b/SpiceSharp/Components/Semiconductors/Bipolar/BipolarJunctionTransistorModel.cs
@@ -1,4 +1,5 @@
-﻿using SpiceSharp.Components.BipolarBehaviors;
+﻿using SpiceSharp.Behaviors;
+using SpiceSharp.Components.BipolarBehaviors;
 
 namespace SpiceSharp.Components
 {
@@ -7,6 +8,14 @@ namespace SpiceSharp.Components
     /// </summary>
     public class BipolarJunctionTransistorModel : Model
     {
+        static BipolarJunctionTransistorModel()
+        {
+            RegisterBehaviorFactory(typeof(BipolarJunctionTransistorModel), new BehaviorFactoryDictionary
+            {
+                {typeof(ModelTemperatureBehavior), name => new ModelTemperatureBehavior(name)}
+            });
+        }
+
         /// <summary>
         /// Constructor
         /// </summary>
@@ -16,9 +25,6 @@ namespace SpiceSharp.Components
             // Add parameters
             ParameterSets.Add(new ModelBaseParameters());
             ParameterSets.Add(new ModelNoiseParameters());
-
-            // Add factories
-            Behaviors.Add(typeof(ModelTemperatureBehavior), () => new ModelTemperatureBehavior(Name));
         }
     }
 }

--- a/SpiceSharp/Components/Semiconductors/Bipolar/BipolarJunctionTransistorModel.cs
+++ b/SpiceSharp/Components/Semiconductors/Bipolar/BipolarJunctionTransistorModel.cs
@@ -12,7 +12,7 @@ namespace SpiceSharp.Components
         {
             RegisterBehaviorFactory(typeof(BipolarJunctionTransistorModel), new BehaviorFactoryDictionary
             {
-                {typeof(ModelTemperatureBehavior), name => new ModelTemperatureBehavior(name)}
+                {typeof(ModelTemperatureBehavior), e => new ModelTemperatureBehavior(e.Name)}
             });
         }
 

--- a/SpiceSharp/Components/Semiconductors/DIO/Diode.cs
+++ b/SpiceSharp/Components/Semiconductors/DIO/Diode.cs
@@ -1,4 +1,5 @@
 ﻿using SpiceSharp.Attributes;
+using SpiceSharp.Behaviors;
 using SpiceSharp.Components.DiodeBehaviors;
 
 namespace SpiceSharp.Components
@@ -9,6 +10,18 @@ namespace SpiceSharp.Components
     [Pin(0, "D+"), Pin(1, "D-")]
     public class Diode : Component
     {
+        static Diode()
+        {
+            RegisterBehaviorFactory(typeof(Diode), new BehaviorFactoryDictionary
+            {
+                {typeof(BiasingBehavior), name => new BiasingBehavior(name)},
+                {typeof(TransientBehavior), name => new TransientBehavior(name)},
+                {typeof(TemperatureBehavior), name => new TemperatureBehavior(name)},
+                {typeof(FrequencyBehavior), name => new FrequencyBehavior(name)},
+                {typeof(NoiseBehavior), name => new NoiseBehavior(name)}
+            });
+        }
+
         /// <summary>
         /// Set the model for the diode
         /// </summary>
@@ -28,13 +41,6 @@ namespace SpiceSharp.Components
         {
             // Add parameters
             ParameterSets.Add(new BaseParameters());
-
-            // Add factories
-            Behaviors.Add(typeof(BiasingBehavior), () => new BiasingBehavior(Name));
-            Behaviors.Add(typeof(TransientBehavior), () => new TransientBehavior(Name));
-            Behaviors.Add(typeof(TemperatureBehavior), () => new TemperatureBehavior(Name));
-            Behaviors.Add(typeof(FrequencyBehavior), () => new FrequencyBehavior(Name));
-            Behaviors.Add(typeof(NoiseBehavior), () => new NoiseBehavior(Name));
         }
 
         /// <summary>

--- a/SpiceSharp/Components/Semiconductors/DIO/Diode.cs
+++ b/SpiceSharp/Components/Semiconductors/DIO/Diode.cs
@@ -14,11 +14,11 @@ namespace SpiceSharp.Components
         {
             RegisterBehaviorFactory(typeof(Diode), new BehaviorFactoryDictionary
             {
-                {typeof(BiasingBehavior), name => new BiasingBehavior(name)},
-                {typeof(TransientBehavior), name => new TransientBehavior(name)},
-                {typeof(TemperatureBehavior), name => new TemperatureBehavior(name)},
-                {typeof(FrequencyBehavior), name => new FrequencyBehavior(name)},
-                {typeof(NoiseBehavior), name => new NoiseBehavior(name)}
+                {typeof(BiasingBehavior), e => new BiasingBehavior(e.Name)},
+                {typeof(TransientBehavior), e => new TransientBehavior(e.Name)},
+                {typeof(TemperatureBehavior), e => new TemperatureBehavior(e.Name)},
+                {typeof(FrequencyBehavior), e => new FrequencyBehavior(e.Name)},
+                {typeof(NoiseBehavior), e => new NoiseBehavior(e.Name)}
             });
         }
 
@@ -39,7 +39,6 @@ namespace SpiceSharp.Components
         /// <param name="name">The name of the device</param>
         public Diode(string name) : base(name, DiodePinCount)
         {
-            // Add parameters
             ParameterSets.Add(new BaseParameters());
         }
 

--- a/SpiceSharp/Components/Semiconductors/DIO/DiodeModel.cs
+++ b/SpiceSharp/Components/Semiconductors/DIO/DiodeModel.cs
@@ -1,4 +1,5 @@
-﻿using SpiceSharp.Components.DiodeBehaviors;
+﻿using SpiceSharp.Behaviors;
+using SpiceSharp.Components.DiodeBehaviors;
 
 namespace SpiceSharp.Components
 {
@@ -7,6 +8,14 @@ namespace SpiceSharp.Components
     /// </summary>
     public class DiodeModel : Model
     {
+        static DiodeModel()
+        {
+            RegisterBehaviorFactory(typeof(DiodeModel), new BehaviorFactoryDictionary
+            {
+                {typeof(ModelTemperatureBehavior), name => new ModelTemperatureBehavior(name)}
+            });
+        }
+
         /// <summary>
         /// Constructor
         /// </summary>
@@ -16,9 +25,6 @@ namespace SpiceSharp.Components
             // Add parameters
             ParameterSets.Add(new ModelBaseParameters());
             ParameterSets.Add(new ModelNoiseParameters());
-
-            // Add factories
-            Behaviors.Add(typeof(ModelTemperatureBehavior), () => new ModelTemperatureBehavior(Name));
         }
     }
 }

--- a/SpiceSharp/Components/Semiconductors/DIO/DiodeModel.cs
+++ b/SpiceSharp/Components/Semiconductors/DIO/DiodeModel.cs
@@ -12,7 +12,7 @@ namespace SpiceSharp.Components
         {
             RegisterBehaviorFactory(typeof(DiodeModel), new BehaviorFactoryDictionary
             {
-                {typeof(ModelTemperatureBehavior), name => new ModelTemperatureBehavior(name)}
+                {typeof(ModelTemperatureBehavior), e => new ModelTemperatureBehavior(e.Name)}
             });
         }
 
@@ -22,7 +22,6 @@ namespace SpiceSharp.Components
         /// <param name="name">The name of the device</param>
         public DiodeModel(string name) : base(name)
         {
-            // Add parameters
             ParameterSets.Add(new ModelBaseParameters());
             ParameterSets.Add(new ModelNoiseParameters());
         }

--- a/SpiceSharp/Components/Semiconductors/JFET/JFET.cs
+++ b/SpiceSharp/Components/Semiconductors/JFET/JFET.cs
@@ -1,4 +1,5 @@
 ﻿using SpiceSharp.Attributes;
+using SpiceSharp.Behaviors;
 using SpiceSharp.Components.JFETBehaviors;
 
 namespace SpiceSharp.Components
@@ -10,6 +11,18 @@ namespace SpiceSharp.Components
     [Pin(0, "drain"), Pin(1, "gate"), Pin(2, "source")]
     public class JFET : Component
     {
+        static JFET()
+        {
+            RegisterBehaviorFactory(typeof(JFET), new BehaviorFactoryDictionary
+            {
+                // Add behavior factories
+                {typeof(TemperatureBehavior), name => new TemperatureBehavior(name)},
+                {typeof(BiasingBehavior), name => new BiasingBehavior(name)},
+                {typeof(FrequencyBehavior), name => new FrequencyBehavior(name)},
+                {typeof(TransientBehavior), name => new TransientBehavior(name)}
+            });
+        }
+
         /// <summary>
         /// Sets the model.
         /// </summary>
@@ -30,12 +43,6 @@ namespace SpiceSharp.Components
         {
             // Add parameters
             ParameterSets.Add(new BaseParameters());
-
-            // Add behavior factories
-            Behaviors.Add(typeof(TemperatureBehavior), () => new TemperatureBehavior(Name));
-            Behaviors.Add(typeof(BiasingBehavior), () => new BiasingBehavior(Name));
-            Behaviors.Add(typeof(FrequencyBehavior), () => new FrequencyBehavior(Name));
-            Behaviors.Add(typeof(TransientBehavior), () => new TransientBehavior(Name));
         }
     }
 }

--- a/SpiceSharp/Components/Semiconductors/JFET/JFET.cs
+++ b/SpiceSharp/Components/Semiconductors/JFET/JFET.cs
@@ -16,10 +16,10 @@ namespace SpiceSharp.Components
             RegisterBehaviorFactory(typeof(JFET), new BehaviorFactoryDictionary
             {
                 // Add behavior factories
-                {typeof(TemperatureBehavior), name => new TemperatureBehavior(name)},
-                {typeof(BiasingBehavior), name => new BiasingBehavior(name)},
-                {typeof(FrequencyBehavior), name => new FrequencyBehavior(name)},
-                {typeof(TransientBehavior), name => new TransientBehavior(name)}
+                {typeof(TemperatureBehavior), e => new TemperatureBehavior(e.Name)},
+                {typeof(BiasingBehavior), e => new BiasingBehavior(e.Name)},
+                {typeof(FrequencyBehavior), e => new FrequencyBehavior(e.Name)},
+                {typeof(TransientBehavior), e => new TransientBehavior(e.Name)}
             });
         }
 
@@ -41,7 +41,6 @@ namespace SpiceSharp.Components
         public JFET(string name)
             : base(name, JFETPincount)
         {
-            // Add parameters
             ParameterSets.Add(new BaseParameters());
         }
     }

--- a/SpiceSharp/Components/Semiconductors/JFET/JFETModel.cs
+++ b/SpiceSharp/Components/Semiconductors/JFET/JFETModel.cs
@@ -13,7 +13,7 @@ namespace SpiceSharp.Components
         {
             RegisterBehaviorFactory(typeof(JFETModel), new BehaviorFactoryDictionary
             {
-                {typeof(ModelTemperatureBehavior), name => new ModelTemperatureBehavior(name)}
+                {typeof(ModelTemperatureBehavior), e => new ModelTemperatureBehavior(e.Name)}
             });
         }
 
@@ -24,7 +24,6 @@ namespace SpiceSharp.Components
         public JFETModel(string name)
             : base(name)
         {
-            // Add parameters
             ParameterSets.Add(new ModelBaseParameters());
             ParameterSets.Add(new ModelNoiseParameters());
         }

--- a/SpiceSharp/Components/Semiconductors/JFET/JFETModel.cs
+++ b/SpiceSharp/Components/Semiconductors/JFET/JFETModel.cs
@@ -1,4 +1,5 @@
-﻿using SpiceSharp.Components.JFETBehaviors;
+﻿using SpiceSharp.Behaviors;
+using SpiceSharp.Components.JFETBehaviors;
 
 namespace SpiceSharp.Components
 {
@@ -8,6 +9,14 @@ namespace SpiceSharp.Components
     /// <seealso cref="SpiceSharp.Components.Model" />
     public class JFETModel : Model
     {
+        static JFETModel()
+        {
+            RegisterBehaviorFactory(typeof(JFETModel), new BehaviorFactoryDictionary
+            {
+                {typeof(ModelTemperatureBehavior), name => new ModelTemperatureBehavior(name)}
+            });
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="JFETModel"/> class.
         /// </summary>
@@ -18,9 +27,6 @@ namespace SpiceSharp.Components
             // Add parameters
             ParameterSets.Add(new ModelBaseParameters());
             ParameterSets.Add(new ModelNoiseParameters());
-
-            // Add behavior factories
-            Behaviors.Add(typeof(ModelTemperatureBehavior), () => new ModelTemperatureBehavior(Name));
         }
     }
 }

--- a/SpiceSharp/Components/Semiconductors/MOS/Level1/Mosfet1.cs
+++ b/SpiceSharp/Components/Semiconductors/MOS/Level1/Mosfet1.cs
@@ -1,4 +1,5 @@
 ﻿using SpiceSharp.Attributes;
+using SpiceSharp.Behaviors;
 using SpiceSharp.Components.MosfetBehaviors.Level1;
 
 namespace SpiceSharp.Components
@@ -10,6 +11,18 @@ namespace SpiceSharp.Components
     [Pin(0, "Drain"), Pin(1, "Gate"), Pin(2, "Source"), Pin(3, "Bulk"), Connected(0, 2), Connected(0, 3)]
     public class Mosfet1 : Component
     {
+        static Mosfet1()
+        {
+            RegisterBehaviorFactory(typeof(Mosfet1), new BehaviorFactoryDictionary
+            {
+                {typeof(TemperatureBehavior), name => new TemperatureBehavior(name)},
+                {typeof(BiasingBehavior), name => new BiasingBehavior(name)},
+                {typeof(TransientBehavior), name => new TransientBehavior(name)},
+                {typeof(FrequencyBehavior), name => new FrequencyBehavior(name)},
+                {typeof(NoiseBehavior), name => new NoiseBehavior(name)},
+            });
+        }
+
         /// <summary>
         /// Set the model for the MOS1 Mosfet
         /// </summary>
@@ -29,13 +42,6 @@ namespace SpiceSharp.Components
         {
             // Add parameters
             ParameterSets.Add(new BaseParameters());
-
-            // Add factories
-            Behaviors.Add(typeof(TemperatureBehavior), () => new TemperatureBehavior(Name));
-            Behaviors.Add(typeof(BiasingBehavior), () => new BiasingBehavior(Name));
-            Behaviors.Add(typeof(TransientBehavior), () => new TransientBehavior(Name));
-            Behaviors.Add(typeof(FrequencyBehavior), () => new FrequencyBehavior(Name));
-            Behaviors.Add(typeof(NoiseBehavior), () => new NoiseBehavior(Name));
         }
 
         /// <summary>

--- a/SpiceSharp/Components/Semiconductors/MOS/Level1/Mosfet1.cs
+++ b/SpiceSharp/Components/Semiconductors/MOS/Level1/Mosfet1.cs
@@ -15,11 +15,11 @@ namespace SpiceSharp.Components
         {
             RegisterBehaviorFactory(typeof(Mosfet1), new BehaviorFactoryDictionary
             {
-                {typeof(TemperatureBehavior), name => new TemperatureBehavior(name)},
-                {typeof(BiasingBehavior), name => new BiasingBehavior(name)},
-                {typeof(TransientBehavior), name => new TransientBehavior(name)},
-                {typeof(FrequencyBehavior), name => new FrequencyBehavior(name)},
-                {typeof(NoiseBehavior), name => new NoiseBehavior(name)},
+                {typeof(TemperatureBehavior), e => new TemperatureBehavior(e.Name)},
+                {typeof(BiasingBehavior), e => new BiasingBehavior(e.Name)},
+                {typeof(TransientBehavior), e => new TransientBehavior(e.Name)},
+                {typeof(FrequencyBehavior), e => new FrequencyBehavior(e.Name)},
+                {typeof(NoiseBehavior), e => new NoiseBehavior(e.Name)},
             });
         }
 
@@ -40,7 +40,6 @@ namespace SpiceSharp.Components
         /// <param name="name">The name of the device</param>
         public Mosfet1(string name) : base(name, Mosfet1PinCount)
         {
-            // Add parameters
             ParameterSets.Add(new BaseParameters());
         }
 

--- a/SpiceSharp/Components/Semiconductors/MOS/Level1/Mosfet1Model.cs
+++ b/SpiceSharp/Components/Semiconductors/MOS/Level1/Mosfet1Model.cs
@@ -12,7 +12,7 @@ namespace SpiceSharp.Components
         {
             RegisterBehaviorFactory(typeof(Mosfet1Model), new BehaviorFactoryDictionary
             {
-                {typeof(ModelTemperatureBehavior), name => new ModelTemperatureBehavior(name)}
+                {typeof(ModelTemperatureBehavior), e => new ModelTemperatureBehavior(e.Name)}
             });
         }
 
@@ -22,7 +22,6 @@ namespace SpiceSharp.Components
         /// <param name="name">The name of the device</param>
         public Mosfet1Model(string name) : base(name)
         {
-            // Add parameters
             ParameterSets.Add(new ModelBaseParameters());
             ParameterSets.Add(new MosfetBehaviors.Common.ModelNoiseParameters());
         }

--- a/SpiceSharp/Components/Semiconductors/MOS/Level1/Mosfet1Model.cs
+++ b/SpiceSharp/Components/Semiconductors/MOS/Level1/Mosfet1Model.cs
@@ -1,4 +1,5 @@
-﻿using SpiceSharp.Components.MosfetBehaviors.Level1;
+﻿using SpiceSharp.Behaviors;
+using SpiceSharp.Components.MosfetBehaviors.Level1;
 
 namespace SpiceSharp.Components
 {
@@ -7,6 +8,14 @@ namespace SpiceSharp.Components
     /// </summary>
     public class Mosfet1Model : Model
     {
+        static Mosfet1Model()
+        {
+            RegisterBehaviorFactory(typeof(Mosfet1Model), new BehaviorFactoryDictionary
+            {
+                {typeof(ModelTemperatureBehavior), name => new ModelTemperatureBehavior(name)}
+            });
+        }
+
         /// <summary>
         /// Constructor
         /// </summary>
@@ -16,9 +25,6 @@ namespace SpiceSharp.Components
             // Add parameters
             ParameterSets.Add(new ModelBaseParameters());
             ParameterSets.Add(new MosfetBehaviors.Common.ModelNoiseParameters());
-
-            // Add factories
-            Behaviors.Add(typeof(ModelTemperatureBehavior), () => new ModelTemperatureBehavior(Name));
         }
     }
 }

--- a/SpiceSharp/Components/Semiconductors/MOS/Level2/Mosfet2.cs
+++ b/SpiceSharp/Components/Semiconductors/MOS/Level2/Mosfet2.cs
@@ -15,11 +15,11 @@ namespace SpiceSharp.Components
         {
             RegisterBehaviorFactory(typeof(Mosfet2), new BehaviorFactoryDictionary
             {
-                {typeof(TemperatureBehavior), name => new TemperatureBehavior(name)},
-                {typeof(BiasingBehavior), name => new BiasingBehavior(name)},
-                {typeof(FrequencyBehavior), name => new FrequencyBehavior(name)},
-                {typeof(TransientBehavior), name => new TransientBehavior(name)},
-                {typeof(NoiseBehavior), name => new NoiseBehavior(name)}
+                {typeof(TemperatureBehavior), e => new TemperatureBehavior(e.Name)},
+                {typeof(BiasingBehavior), e => new BiasingBehavior(e.Name)},
+                {typeof(FrequencyBehavior), e => new FrequencyBehavior(e.Name)},
+                {typeof(TransientBehavior), e => new TransientBehavior(e.Name)},
+                {typeof(NoiseBehavior), e => new NoiseBehavior(e.Name)}
             });
         }
 
@@ -40,7 +40,6 @@ namespace SpiceSharp.Components
         /// <param name="name">The name of the device</param>
         public Mosfet2(string name) : base(name, Mosfet2PinCount)
         {
-            // Add parameters
             ParameterSets.Add(new BaseParameters());
         }
     }

--- a/SpiceSharp/Components/Semiconductors/MOS/Level2/Mosfet2.cs
+++ b/SpiceSharp/Components/Semiconductors/MOS/Level2/Mosfet2.cs
@@ -1,4 +1,5 @@
 ﻿using SpiceSharp.Attributes;
+using SpiceSharp.Behaviors;
 using SpiceSharp.Components.MosfetBehaviors.Level2;
 
 namespace SpiceSharp.Components
@@ -10,6 +11,18 @@ namespace SpiceSharp.Components
     [Pin(0, "Drain"), Pin(1, "Gate"), Pin(2, "Source"), Pin(3, "Bulk"), Connected(0, 2), Connected(0, 3)]
     public class Mosfet2 : Component
     {
+        static Mosfet2()
+        {
+            RegisterBehaviorFactory(typeof(Mosfet2), new BehaviorFactoryDictionary
+            {
+                {typeof(TemperatureBehavior), name => new TemperatureBehavior(name)},
+                {typeof(BiasingBehavior), name => new BiasingBehavior(name)},
+                {typeof(FrequencyBehavior), name => new FrequencyBehavior(name)},
+                {typeof(TransientBehavior), name => new TransientBehavior(name)},
+                {typeof(NoiseBehavior), name => new NoiseBehavior(name)}
+            });
+        }
+
         /// <summary>
         /// Set the model for the MOS2 Mosfet.
         /// </summary>
@@ -29,13 +42,6 @@ namespace SpiceSharp.Components
         {
             // Add parameters
             ParameterSets.Add(new BaseParameters());
-
-            // Add factories
-            Behaviors.Add(typeof(TemperatureBehavior), () => new TemperatureBehavior(Name));
-            Behaviors.Add(typeof(BiasingBehavior), () => new BiasingBehavior(Name));
-            Behaviors.Add(typeof(FrequencyBehavior), () => new FrequencyBehavior(Name));
-            Behaviors.Add(typeof(TransientBehavior), () => new TransientBehavior(Name));
-            Behaviors.Add(typeof(NoiseBehavior), () => new NoiseBehavior(Name));
         }
     }
 }

--- a/SpiceSharp/Components/Semiconductors/MOS/Level2/Mosfet2Model.cs
+++ b/SpiceSharp/Components/Semiconductors/MOS/Level2/Mosfet2Model.cs
@@ -1,4 +1,5 @@
-﻿using SpiceSharp.Components.MosfetBehaviors.Level2;
+﻿using SpiceSharp.Behaviors;
+using SpiceSharp.Components.MosfetBehaviors.Level2;
 
 namespace SpiceSharp.Components
 {
@@ -7,6 +8,14 @@ namespace SpiceSharp.Components
     /// </summary>
     public class Mosfet2Model : Model
     {
+        static Mosfet2Model()
+        {
+            RegisterBehaviorFactory(typeof(Mosfet2Model), new BehaviorFactoryDictionary
+            {
+                {typeof(ModelTemperatureBehavior), name => new ModelTemperatureBehavior(name)}
+            });
+        }
+
         /// <summary>
         /// Constructor
         /// </summary>
@@ -16,9 +25,6 @@ namespace SpiceSharp.Components
             // Add parameters
             ParameterSets.Add(new ModelBaseParameters());
             ParameterSets.Add(new MosfetBehaviors.Common.ModelNoiseParameters());
-
-            // Add factories
-            Behaviors.Add(typeof(ModelTemperatureBehavior), () => new ModelTemperatureBehavior(Name));
         }
     }
 }

--- a/SpiceSharp/Components/Semiconductors/MOS/Level2/Mosfet2Model.cs
+++ b/SpiceSharp/Components/Semiconductors/MOS/Level2/Mosfet2Model.cs
@@ -12,7 +12,7 @@ namespace SpiceSharp.Components
         {
             RegisterBehaviorFactory(typeof(Mosfet2Model), new BehaviorFactoryDictionary
             {
-                {typeof(ModelTemperatureBehavior), name => new ModelTemperatureBehavior(name)}
+                {typeof(ModelTemperatureBehavior), e => new ModelTemperatureBehavior(e.Name)}
             });
         }
 
@@ -22,7 +22,6 @@ namespace SpiceSharp.Components
         /// <param name="name">The name of the device</param>
         public Mosfet2Model(string name) : base(name)
         {
-            // Add parameters
             ParameterSets.Add(new ModelBaseParameters());
             ParameterSets.Add(new MosfetBehaviors.Common.ModelNoiseParameters());
         }

--- a/SpiceSharp/Components/Semiconductors/MOS/Level3/Mosfet3.cs
+++ b/SpiceSharp/Components/Semiconductors/MOS/Level3/Mosfet3.cs
@@ -1,4 +1,5 @@
 ﻿using SpiceSharp.Attributes;
+using SpiceSharp.Behaviors;
 using SpiceSharp.Components.MosfetBehaviors.Level3;
 
 namespace SpiceSharp.Components
@@ -10,6 +11,18 @@ namespace SpiceSharp.Components
     [Pin(0, "Drain"), Pin(1, "Gate"), Pin(2, "Source"), Pin(3, "Bulk"), Connected(0, 2), Connected(0, 3)]
     public class Mosfet3 : Component
     {
+        static Mosfet3()
+        {
+            RegisterBehaviorFactory(typeof(Mosfet3), new BehaviorFactoryDictionary
+            {
+                {typeof(TemperatureBehavior), name => new TemperatureBehavior(name)},
+                {typeof(BiasingBehavior), name => new BiasingBehavior(name)},
+                {typeof(FrequencyBehavior), name => new FrequencyBehavior(name)},
+                {typeof(TransientBehavior), name => new TransientBehavior(name)},
+                {typeof(NoiseBehavior), name => new NoiseBehavior(name)}
+            });
+        }
+
         /// <summary>
         /// Set the model for the MOS3 model
         /// </summary>
@@ -29,13 +42,6 @@ namespace SpiceSharp.Components
         {
             // Add parameters
             ParameterSets.Add(new BaseParameters());
-
-            // Add factories
-            Behaviors.Add(typeof(TemperatureBehavior), () => new TemperatureBehavior(Name));
-            Behaviors.Add(typeof(BiasingBehavior), () => new BiasingBehavior(Name));
-            Behaviors.Add(typeof(FrequencyBehavior), () => new FrequencyBehavior(Name));
-            Behaviors.Add(typeof(TransientBehavior), () => new TransientBehavior(Name));
-            Behaviors.Add(typeof(NoiseBehavior), () => new NoiseBehavior(Name));
         }
     }
 }

--- a/SpiceSharp/Components/Semiconductors/MOS/Level3/Mosfet3.cs
+++ b/SpiceSharp/Components/Semiconductors/MOS/Level3/Mosfet3.cs
@@ -15,11 +15,11 @@ namespace SpiceSharp.Components
         {
             RegisterBehaviorFactory(typeof(Mosfet3), new BehaviorFactoryDictionary
             {
-                {typeof(TemperatureBehavior), name => new TemperatureBehavior(name)},
-                {typeof(BiasingBehavior), name => new BiasingBehavior(name)},
-                {typeof(FrequencyBehavior), name => new FrequencyBehavior(name)},
-                {typeof(TransientBehavior), name => new TransientBehavior(name)},
-                {typeof(NoiseBehavior), name => new NoiseBehavior(name)}
+                {typeof(TemperatureBehavior), e => new TemperatureBehavior(e.Name)},
+                {typeof(BiasingBehavior), e => new BiasingBehavior(e.Name)},
+                {typeof(FrequencyBehavior), e => new FrequencyBehavior(e.Name)},
+                {typeof(TransientBehavior), e => new TransientBehavior(e.Name)},
+                {typeof(NoiseBehavior), e => new NoiseBehavior(e.Name)}
             });
         }
 
@@ -40,7 +40,6 @@ namespace SpiceSharp.Components
         /// <param name="name">The name of the device</param>
         public Mosfet3(string name) : base(name, Mosfet3PinCount)
         {
-            // Add parameters
             ParameterSets.Add(new BaseParameters());
         }
     }

--- a/SpiceSharp/Components/Semiconductors/MOS/Level3/Mosfet3Model.cs
+++ b/SpiceSharp/Components/Semiconductors/MOS/Level3/Mosfet3Model.cs
@@ -12,7 +12,7 @@ namespace SpiceSharp.Components
         {
             RegisterBehaviorFactory(typeof(Mosfet3Model), new BehaviorFactoryDictionary
             {
-                {typeof(ModelTemperatureBehavior), name => new ModelTemperatureBehavior(name)}
+                {typeof(ModelTemperatureBehavior), e => new ModelTemperatureBehavior(e.Name)}
             });
         }
 
@@ -22,7 +22,6 @@ namespace SpiceSharp.Components
         /// <param name="name">The name of the device</param>
         public Mosfet3Model(string name) : base(name)
         {
-            // Add parameters
             ParameterSets.Add(new ModelBaseParameters());
             ParameterSets.Add(new MosfetBehaviors.Common.ModelNoiseParameters());
         }
@@ -34,7 +33,6 @@ namespace SpiceSharp.Components
         /// <param name="nmos">True for NMOS transistors, false for PMOS transistors</param>
         public Mosfet3Model(string name, bool nmos) : base(name)
         {
-            // Add parameters
             ParameterSets.Add(new ModelBaseParameters(nmos));
             ParameterSets.Add(new MosfetBehaviors.Common.ModelNoiseParameters());
         }

--- a/SpiceSharp/Components/Semiconductors/MOS/Level3/Mosfet3Model.cs
+++ b/SpiceSharp/Components/Semiconductors/MOS/Level3/Mosfet3Model.cs
@@ -1,4 +1,5 @@
-﻿using SpiceSharp.Components.MosfetBehaviors.Level3;
+﻿using SpiceSharp.Behaviors;
+using SpiceSharp.Components.MosfetBehaviors.Level3;
 
 namespace SpiceSharp.Components
 {
@@ -7,6 +8,14 @@ namespace SpiceSharp.Components
     /// </summary>
     public class Mosfet3Model : Model
     {
+        static Mosfet3Model()
+        {
+            RegisterBehaviorFactory(typeof(Mosfet3Model), new BehaviorFactoryDictionary
+            {
+                {typeof(ModelTemperatureBehavior), name => new ModelTemperatureBehavior(name)}
+            });
+        }
+
         /// <summary>
         /// Constructor
         /// </summary>
@@ -16,9 +25,6 @@ namespace SpiceSharp.Components
             // Add parameters
             ParameterSets.Add(new ModelBaseParameters());
             ParameterSets.Add(new MosfetBehaviors.Common.ModelNoiseParameters());
-
-            // Add factories
-            Behaviors.Add(typeof(ModelTemperatureBehavior), () => new ModelTemperatureBehavior(Name));
         }
 
         /// <summary>
@@ -31,9 +37,6 @@ namespace SpiceSharp.Components
             // Add parameters
             ParameterSets.Add(new ModelBaseParameters(nmos));
             ParameterSets.Add(new MosfetBehaviors.Common.ModelNoiseParameters());
-
-            // Add factories
-            Behaviors.Add(typeof(ModelTemperatureBehavior), () => new ModelTemperatureBehavior(Name));
         }
     }
 }

--- a/SpiceSharp/Components/Switches/CSW/CurrentSwitch.cs
+++ b/SpiceSharp/Components/Switches/CSW/CurrentSwitch.cs
@@ -11,6 +11,17 @@ namespace SpiceSharp.Components
     [Pin(0, "W+"), Pin(1, "W-")]
     public class CurrentSwitch : Component
     {
+        static CurrentSwitch()
+        {
+            RegisterBehaviorFactory(typeof(CurrentSwitch), new BehaviorFactoryDictionary
+            {
+                // Add factories
+                {typeof(BiasingBehavior), name => new BiasingBehavior(name, new CurrentControlled())},
+                {typeof(AcceptBehavior), name => new AcceptBehavior(name, new CurrentControlled())},
+                {typeof(FrequencyBehavior), name => new FrequencyBehavior(name, new CurrentControlled())}
+            });
+        }
+
         /// <summary>
         /// Set the model for the current-controlled switch
         /// </summary>
@@ -39,11 +50,6 @@ namespace SpiceSharp.Components
 
             // Add parameters
             ParameterSets.Add(new BaseParameters());
-
-            // Add factories
-            Behaviors.Add(typeof(BiasingBehavior), () => new BiasingBehavior(Name, new CurrentControlled()));
-            Behaviors.Add(typeof(AcceptBehavior), () => new AcceptBehavior(Name, new CurrentControlled()));
-            Behaviors.Add(typeof(FrequencyBehavior), () => new FrequencyBehavior(Name, new CurrentControlled()));
         }
 
         /// <summary>
@@ -62,13 +68,7 @@ namespace SpiceSharp.Components
             // Add parameters
             ParameterSets.Add(new BaseParameters());
 
-            // Add factories
-            
-            // Add factories
-            Behaviors.Add(typeof(BiasingBehavior), () => new BiasingBehavior(Name, new CurrentControlled()));
-            Behaviors.Add(typeof(AcceptBehavior), () => new AcceptBehavior(Name, new CurrentControlled()));
-            Behaviors.Add(typeof(FrequencyBehavior), () => new FrequencyBehavior(Name, new CurrentControlled()));
-
+            // Connect the device
             Connect(pos, neg);
             ControllingName = controllingSource;
         }

--- a/SpiceSharp/Components/Switches/CSW/CurrentSwitch.cs
+++ b/SpiceSharp/Components/Switches/CSW/CurrentSwitch.cs
@@ -16,9 +16,9 @@ namespace SpiceSharp.Components
             RegisterBehaviorFactory(typeof(CurrentSwitch), new BehaviorFactoryDictionary
             {
                 // Add factories
-                {typeof(BiasingBehavior), name => new BiasingBehavior(name, new CurrentControlled())},
-                {typeof(AcceptBehavior), name => new AcceptBehavior(name, new CurrentControlled())},
-                {typeof(FrequencyBehavior), name => new FrequencyBehavior(name, new CurrentControlled())}
+                {typeof(BiasingBehavior), e => new BiasingBehavior(e.Name, new CurrentControlled())},
+                {typeof(AcceptBehavior), e => new AcceptBehavior(e.Name, new CurrentControlled())},
+                {typeof(FrequencyBehavior), e => new FrequencyBehavior(e.Name, new CurrentControlled())}
             });
         }
 
@@ -45,10 +45,7 @@ namespace SpiceSharp.Components
         /// <param name="name">The name of the current-controlled switch</param>
         public CurrentSwitch(string name) : base(name, CurrentSwitchPinCount)
         {
-            // Make sure the current switch is processed after voltage sources
-            Priority = -1;
-
-            // Add parameters
+            Priority = ComponentPriority - 1;
             ParameterSets.Add(new BaseParameters());
         }
 
@@ -62,13 +59,8 @@ namespace SpiceSharp.Components
         public CurrentSwitch(string name, string pos, string neg, string controllingSource)
             : base(name, CurrentSwitchPinCount)
         {
-            // Make sure the current switch is processed after voltage sources
-            Priority = -1;
-
-            // Add parameters
+            Priority = ComponentPriority - 1;
             ParameterSets.Add(new BaseParameters());
-
-            // Connect the device
             Connect(pos, neg);
             ControllingName = controllingSource;
         }

--- a/SpiceSharp/Components/Switches/VSW/VoltageSwitch.cs
+++ b/SpiceSharp/Components/Switches/VSW/VoltageSwitch.cs
@@ -1,4 +1,5 @@
 ﻿using SpiceSharp.Attributes;
+using SpiceSharp.Behaviors;
 using SpiceSharp.Components.SwitchBehaviors;
 
 namespace SpiceSharp.Components
@@ -9,6 +10,17 @@ namespace SpiceSharp.Components
     [Pin(0, "S+"), Pin(1, "S-"), Pin(2, "SC+"), Pin(3, "SC-"), Connected(0, 1)]
     public class VoltageSwitch : Component
     {
+        static VoltageSwitch()
+        {
+            RegisterBehaviorFactory(typeof(VoltageSwitch), new BehaviorFactoryDictionary
+            {
+                // Add factories
+                {typeof(BiasingBehavior), name => new BiasingBehavior(name, new VoltageControlled())},
+                {typeof(FrequencyBehavior), name => new FrequencyBehavior(name, new VoltageControlled())},
+                {typeof(AcceptBehavior), name => new AcceptBehavior(name, new VoltageControlled())}
+            });
+        }
+
         /// <summary>
         /// Set the model for the voltage-controlled switch
         /// </summary>
@@ -27,13 +39,7 @@ namespace SpiceSharp.Components
         public VoltageSwitch(string name) 
             : base(name, VoltageSwitchPinCount)
         {
-            // Register parameters
             ParameterSets.Add(new BaseParameters());
-
-            // Add factories
-            Behaviors.Add(typeof(BiasingBehavior), () => new BiasingBehavior(Name, new VoltageControlled()));
-            Behaviors.Add(typeof(FrequencyBehavior), () => new FrequencyBehavior(Name, new VoltageControlled()));
-            Behaviors.Add(typeof(AcceptBehavior), () => new AcceptBehavior(Name, new VoltageControlled()));
         }
 
         /// <summary>
@@ -45,16 +51,8 @@ namespace SpiceSharp.Components
         /// <param name="controlPos">The positive controlling node</param>
         /// <param name="controlNeg">The negative controlling node</param>
         public VoltageSwitch(string name, string pos, string neg, string controlPos, string controlNeg) 
-            : base(name, VoltageSwitchPinCount)
+            : this(name)
         {
-            // Register parameters
-            ParameterSets.Add(new BaseParameters());
-
-            // Add factories
-            Behaviors.Add(typeof(BiasingBehavior), () => new BiasingBehavior(Name, new VoltageControlled()));
-            Behaviors.Add(typeof(FrequencyBehavior), () => new FrequencyBehavior(Name, new VoltageControlled()));
-            Behaviors.Add(typeof(AcceptBehavior), () => new AcceptBehavior(Name, new VoltageControlled()));
-
             Connect(pos, neg, controlPos, controlNeg);
         }
     }

--- a/SpiceSharp/Components/Switches/VSW/VoltageSwitch.cs
+++ b/SpiceSharp/Components/Switches/VSW/VoltageSwitch.cs
@@ -15,9 +15,9 @@ namespace SpiceSharp.Components
             RegisterBehaviorFactory(typeof(VoltageSwitch), new BehaviorFactoryDictionary
             {
                 // Add factories
-                {typeof(BiasingBehavior), name => new BiasingBehavior(name, new VoltageControlled())},
-                {typeof(FrequencyBehavior), name => new FrequencyBehavior(name, new VoltageControlled())},
-                {typeof(AcceptBehavior), name => new AcceptBehavior(name, new VoltageControlled())}
+                {typeof(BiasingBehavior), e => new BiasingBehavior(e.Name, new VoltageControlled())},
+                {typeof(FrequencyBehavior), e => new FrequencyBehavior(e.Name, new VoltageControlled())},
+                {typeof(AcceptBehavior), e => new AcceptBehavior(e.Name, new VoltageControlled())}
             });
         }
 

--- a/SpiceSharp/Components/Voltagesources/CCVS/CurrentControlledVoltageSource.cs
+++ b/SpiceSharp/Components/Voltagesources/CCVS/CurrentControlledVoltageSource.cs
@@ -15,8 +15,8 @@ namespace SpiceSharp.Components
         {
             RegisterBehaviorFactory(typeof(CurrentControlledVoltageSource), new BehaviorFactoryDictionary
             {
-                {typeof(BiasingBehavior), name => new BiasingBehavior(name)},
-                {typeof(FrequencyBehavior), name => new FrequencyBehavior(name)}
+                {typeof(BiasingBehavior), e => new BiasingBehavior(e.Name)},
+                {typeof(FrequencyBehavior), e => new FrequencyBehavior(e.Name)}
             });
         }
 
@@ -39,10 +39,7 @@ namespace SpiceSharp.Components
         public CurrentControlledVoltageSource(string name) 
             : base(name, CurrentControlledVoltageSourcePinCount)
         {
-            // Make sure we are placed behind any voltage sources
             Priority = ComponentPriority - 1;
-
-            // Add parameters
             ParameterSets.Add(new BaseParameters());
         }
 
@@ -57,7 +54,6 @@ namespace SpiceSharp.Components
         public CurrentControlledVoltageSource(string name, string pos, string neg, string controllingSource, double gain) 
             : base(name, CurrentControlledVoltageSourcePinCount)
         {
-            // Make sure we are placed behind any voltage sources
             Priority = ComponentPriority - 1;
             ParameterSets.Add(new BaseParameters(gain));
             Connect(pos, neg);

--- a/SpiceSharp/Components/Voltagesources/CCVS/CurrentControlledVoltageSource.cs
+++ b/SpiceSharp/Components/Voltagesources/CCVS/CurrentControlledVoltageSource.cs
@@ -11,6 +11,15 @@ namespace SpiceSharp.Components
     [Pin(0, "H+"), Pin(1, "H-"), VoltageDriver(0, 1)]
     public class CurrentControlledVoltageSource : Component
     {
+        static CurrentControlledVoltageSource()
+        {
+            RegisterBehaviorFactory(typeof(CurrentControlledVoltageSource), new BehaviorFactoryDictionary
+            {
+                {typeof(BiasingBehavior), name => new BiasingBehavior(name)},
+                {typeof(FrequencyBehavior), name => new FrequencyBehavior(name)}
+            });
+        }
+
         /// <summary>
         /// Controlling source name
         /// </summary>
@@ -35,10 +44,6 @@ namespace SpiceSharp.Components
 
             // Add parameters
             ParameterSets.Add(new BaseParameters());
-
-            // Add factories
-            Behaviors.Add(typeof(BiasingBehavior), () => new BiasingBehavior(Name));
-            Behaviors.Add(typeof(FrequencyBehavior), () => new FrequencyBehavior(Name));
         }
 
         /// <summary>
@@ -54,14 +59,7 @@ namespace SpiceSharp.Components
         {
             // Make sure we are placed behind any voltage sources
             Priority = ComponentPriority - 1;
-
-            // Add parameters
             ParameterSets.Add(new BaseParameters(gain));
-
-            // Add factories
-            Behaviors.Add(typeof(BiasingBehavior), () => new BiasingBehavior(Name));
-            Behaviors.Add(typeof(FrequencyBehavior), () => new FrequencyBehavior(Name));
-
             Connect(pos, neg);
             ControllingName = controllingSource;
         }

--- a/SpiceSharp/Components/Voltagesources/VCVS/VoltageControlledVoltageSource.cs
+++ b/SpiceSharp/Components/Voltagesources/VCVS/VoltageControlledVoltageSource.cs
@@ -14,8 +14,8 @@ namespace SpiceSharp.Components
         {
             RegisterBehaviorFactory(typeof(VoltageControlledVoltageSource), new BehaviorFactoryDictionary
             {
-                {typeof(BiasingBehavior), name => new BiasingBehavior(name)},
-                {typeof(FrequencyBehavior), name => new FrequencyBehavior(name)}
+                {typeof(BiasingBehavior), e => new BiasingBehavior(e.Name)},
+                {typeof(FrequencyBehavior), e => new FrequencyBehavior(e.Name)}
             });
         }
 

--- a/SpiceSharp/Components/Voltagesources/VCVS/VoltageControlledVoltageSource.cs
+++ b/SpiceSharp/Components/Voltagesources/VCVS/VoltageControlledVoltageSource.cs
@@ -1,4 +1,5 @@
 ﻿using SpiceSharp.Attributes;
+using SpiceSharp.Behaviors;
 using SpiceSharp.Components.VoltageControlledVoltageSourceBehaviors;
 
 namespace SpiceSharp.Components
@@ -9,6 +10,15 @@ namespace SpiceSharp.Components
     [Pin(0, "V+"), Pin(1, "V-"), Pin(2, "VC+"), Pin(3, "VC-"), VoltageDriver(0, 1), Connected(0, 1)]
     public class VoltageControlledVoltageSource : Component
     {
+        static VoltageControlledVoltageSource()
+        {
+            RegisterBehaviorFactory(typeof(VoltageControlledVoltageSource), new BehaviorFactoryDictionary
+            {
+                {typeof(BiasingBehavior), name => new BiasingBehavior(name)},
+                {typeof(FrequencyBehavior), name => new FrequencyBehavior(name)}
+            });
+        }
+
         /// <summary>
         /// Constants
         /// </summary>
@@ -22,12 +32,7 @@ namespace SpiceSharp.Components
         public VoltageControlledVoltageSource(string name) 
             : base(name, VoltageControlledVoltageSourcePinCount)
         {
-            // Add parameters
             ParameterSets.Add(new BaseParameters());
-
-            // Add factories
-            Behaviors.Add(typeof(BiasingBehavior), () => new BiasingBehavior(Name));
-            Behaviors.Add(typeof(FrequencyBehavior), () => new FrequencyBehavior(Name));
         }
 
         /// <summary>
@@ -42,13 +47,7 @@ namespace SpiceSharp.Components
         public VoltageControlledVoltageSource(string name, string pos, string neg, string controlPos, string controlNeg, double gain) 
             : base(name, VoltageControlledVoltageSourcePinCount)
         {
-            // Add parameters
             ParameterSets.Add(new BaseParameters(gain));
-
-            // Add factories
-            Behaviors.Add(typeof(BiasingBehavior), () => new BiasingBehavior(Name));
-            Behaviors.Add(typeof(FrequencyBehavior), () => new FrequencyBehavior(Name));
-
             Connect(pos, neg, controlPos, controlNeg);
         }
     }

--- a/SpiceSharp/Components/Voltagesources/VSRC/VoltageSource.cs
+++ b/SpiceSharp/Components/Voltagesources/VSRC/VoltageSource.cs
@@ -1,4 +1,5 @@
 ﻿using SpiceSharp.Attributes;
+using SpiceSharp.Behaviors;
 using SpiceSharp.Components.VoltageSourceBehaviors;
 
 namespace SpiceSharp.Components
@@ -9,6 +10,16 @@ namespace SpiceSharp.Components
     [Pin(0, "V+"), Pin(1, "V-"), VoltageDriver(0, 1), IndependentSource]
     public class VoltageSource : Component
     {
+        static VoltageSource()
+        {
+            RegisterBehaviorFactory(typeof(VoltageSource), new BehaviorFactoryDictionary
+            {
+                {typeof(BiasingBehavior), name => new BiasingBehavior(name)},
+                {typeof(FrequencyBehavior), name => new FrequencyBehavior(name)},
+                {typeof(AcceptBehavior), name => new AcceptBehavior(name)}
+            });
+        }
+
         /// <summary>
         /// Constants
         /// </summary>
@@ -24,11 +35,6 @@ namespace SpiceSharp.Components
             // Register parameters
             ParameterSets.Add(new CommonBehaviors.IndependentBaseParameters());
             ParameterSets.Add(new CommonBehaviors.IndependentFrequencyParameters());
-
-            // Register factories
-            Behaviors.Add(typeof(BiasingBehavior), () => new BiasingBehavior(Name));
-            Behaviors.Add(typeof(FrequencyBehavior), () => new FrequencyBehavior(Name));
-            Behaviors.Add(typeof(AcceptBehavior), () => new AcceptBehavior(Name));
         }
 
         /// <summary>
@@ -44,11 +50,6 @@ namespace SpiceSharp.Components
             // Register parameters
             ParameterSets.Add(new CommonBehaviors.IndependentBaseParameters(dc));
             ParameterSets.Add(new CommonBehaviors.IndependentFrequencyParameters());
-
-            // Register factories
-            Behaviors.Add(typeof(BiasingBehavior), () => new BiasingBehavior(Name));
-            Behaviors.Add(typeof(FrequencyBehavior), () => new FrequencyBehavior(Name));
-            Behaviors.Add(typeof(AcceptBehavior), () => new AcceptBehavior(Name));
 
             // Connect the device
             Connect(pos, neg);
@@ -67,11 +68,6 @@ namespace SpiceSharp.Components
             // Register parameters
             ParameterSets.Add(new CommonBehaviors.IndependentBaseParameters(waveform));
             ParameterSets.Add(new CommonBehaviors.IndependentFrequencyParameters());
-
-            // Register factories
-            Behaviors.Add(typeof(BiasingBehavior), () => new BiasingBehavior(Name));
-            Behaviors.Add(typeof(FrequencyBehavior), () => new FrequencyBehavior(Name));
-            Behaviors.Add(typeof(AcceptBehavior), () => new AcceptBehavior(Name));
 
             // Connect the device
             Connect(pos, neg);

--- a/SpiceSharp/Components/Voltagesources/VSRC/VoltageSource.cs
+++ b/SpiceSharp/Components/Voltagesources/VSRC/VoltageSource.cs
@@ -14,9 +14,9 @@ namespace SpiceSharp.Components
         {
             RegisterBehaviorFactory(typeof(VoltageSource), new BehaviorFactoryDictionary
             {
-                {typeof(BiasingBehavior), name => new BiasingBehavior(name)},
-                {typeof(FrequencyBehavior), name => new FrequencyBehavior(name)},
-                {typeof(AcceptBehavior), name => new AcceptBehavior(name)}
+                {typeof(BiasingBehavior), e => new BiasingBehavior(e.Name)},
+                {typeof(FrequencyBehavior), e => new FrequencyBehavior(e.Name)},
+                {typeof(AcceptBehavior), e => new AcceptBehavior(e.Name)}
             });
         }
 
@@ -32,7 +32,6 @@ namespace SpiceSharp.Components
         /// <param name="name">The name</param>
         public VoltageSource(string name) : base(name, VoltageSourcePinCount)
         {
-            // Register parameters
             ParameterSets.Add(new CommonBehaviors.IndependentBaseParameters());
             ParameterSets.Add(new CommonBehaviors.IndependentFrequencyParameters());
         }
@@ -47,11 +46,8 @@ namespace SpiceSharp.Components
         public VoltageSource(string name, string pos, string neg, double dc)
             : base(name, VoltageSourcePinCount)
         {
-            // Register parameters
             ParameterSets.Add(new CommonBehaviors.IndependentBaseParameters(dc));
             ParameterSets.Add(new CommonBehaviors.IndependentFrequencyParameters());
-
-            // Connect the device
             Connect(pos, neg);
         }
 
@@ -65,11 +61,8 @@ namespace SpiceSharp.Components
         public VoltageSource(string name, string pos, string neg, Waveform waveform) 
             : base(name, VoltageSourcePinCount)
         {
-            // Register parameters
             ParameterSets.Add(new CommonBehaviors.IndependentBaseParameters(waveform));
             ParameterSets.Add(new CommonBehaviors.IndependentFrequencyParameters());
-
-            // Connect the device
             Connect(pos, neg);
         }
     }

--- a/SpiceSharp/Simulations/Behaviors/BehaviorFactoryDictionary.cs
+++ b/SpiceSharp/Simulations/Behaviors/BehaviorFactoryDictionary.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-namespace SpiceSharp.Behaviors
+﻿namespace SpiceSharp.Behaviors
 {
     /// <summary>
     /// Factory for behaviors
@@ -12,8 +9,9 @@ namespace SpiceSharp.Behaviors
     }
 
     /// <summary>
-    /// Delegate
+    /// Create a behavior for an entity
     /// </summary>
-    /// <returns>The behavior created by the factory.</returns>
-    public delegate IBehavior BehaviorFactoryMethod();
+    /// <param name="name">The name of the entity creating it.</param>
+    /// <returns></returns>
+    public delegate IBehavior BehaviorFactoryMethod(string name);
 }

--- a/SpiceSharp/Simulations/Behaviors/BehaviorFactoryDictionary.cs
+++ b/SpiceSharp/Simulations/Behaviors/BehaviorFactoryDictionary.cs
@@ -1,4 +1,6 @@
-﻿namespace SpiceSharp.Behaviors
+﻿using SpiceSharp.Circuits;
+
+namespace SpiceSharp.Behaviors
 {
     /// <summary>
     /// Factory for behaviors
@@ -11,7 +13,7 @@
     /// <summary>
     /// Create a behavior for an entity
     /// </summary>
-    /// <param name="name">The name of the entity creating it.</param>
+    /// <param name="entity">The entity creating the behavior.</param>
     /// <returns></returns>
-    public delegate IBehavior BehaviorFactoryMethod(string name);
+    public delegate IBehavior BehaviorFactoryMethod(Entity entity);
 }

--- a/SpiceSharp/Simulations/Exports/ComplexVoltageExport.cs
+++ b/SpiceSharp/Simulations/Exports/ComplexVoltageExport.cs
@@ -75,7 +75,7 @@ namespace SpiceSharp.Simulations
         /// <param name="posNode">The positive node identifier.</param>
         /// <param name="negNode">The negative node identifier.</param>
         /// <exception cref="ArgumentNullException">posNode</exception>
-        public ComplexVoltageExport(FrequencySimulation simulation, string posNode, string negNode)
+        public ComplexVoltageExport(Simulation simulation, string posNode, string negNode)
             : base(simulation)
         {
             PosNode = posNode ?? throw new ArgumentNullException(nameof(posNode));

--- a/SpiceSharp/Simulations/Exports/RealVoltageExport.cs
+++ b/SpiceSharp/Simulations/Exports/RealVoltageExport.cs
@@ -44,7 +44,7 @@ namespace SpiceSharp.Simulations
         /// <param name="posNode">The positive node identifier.</param>
         /// <param name="negNode">The negative node identifier.</param>
         /// <exception cref="ArgumentNullException">posNode</exception>
-        public RealVoltageExport(BaseSimulation simulation, string posNode, string negNode)
+        public RealVoltageExport(Simulation simulation, string posNode, string negNode)
             : base(simulation)
         {
             PosNode = posNode ?? throw new ArgumentNullException(nameof(posNode));

--- a/SpiceSharp/SpiceSharp.csproj
+++ b/SpiceSharp/SpiceSharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.5;netstandard2.0;net45</TargetFrameworks>
-    <Version>2.5.7</Version>
+    <Version>2.5.9</Version>
     <Authors>Sven Boulanger</Authors>
     <Description>Spice# is a circuit simulator based on and improved from Spice 3f5 by Berkeley. The framework allows custom components and simulations to be added.</Description>
     <PackageProjectUrl>https://github.com/SpiceSharp/SpiceSharp</PackageProjectUrl>
@@ -10,12 +10,12 @@
     <RepositoryUrl>https://github.com/SpiceSharp/SpiceSharp</RepositoryUrl>
     <PackageTags>circuit electronics netlist parser spice simulator simulation ode solver design</PackageTags>
     <PackageIconUrl>https://raw.githubusercontent.com/SpiceSharp/SpiceSharp/master/api/images/logo_full.svg?sanitize=true</PackageIconUrl>
-    <AssemblyVersion>2.5.7.0</AssemblyVersion>
+    <AssemblyVersion>2.5.9.0</AssemblyVersion>
     <PackageReleaseNotes>Refer to the GitHub release for release notes</PackageReleaseNotes>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company />
     <NeutralLanguage>en-001</NeutralLanguage>
-    <FileVersion>2.5.7.0</FileVersion>
+    <FileVersion>2.5.9.0</FileVersion>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>

--- a/SpiceSharpTest/Examples/CustomResistor/NonlinearResistor.cs
+++ b/SpiceSharpTest/Examples/CustomResistor/NonlinearResistor.cs
@@ -13,7 +13,7 @@ namespace SpiceSharp.Components
         {
             RegisterBehaviorFactory(typeof(NonlinearResistor), new BehaviorFactoryDictionary
             {
-                {typeof(LoadBehavior), name => new LoadBehavior(name)}
+                {typeof(LoadBehavior), e => new LoadBehavior(e.Name)}
             });
         }
 

--- a/SpiceSharpTest/Examples/CustomResistor/NonlinearResistor.cs
+++ b/SpiceSharpTest/Examples/CustomResistor/NonlinearResistor.cs
@@ -1,4 +1,5 @@
-﻿using SpiceSharp.Components.NonlinearResistorBehaviors;
+﻿using SpiceSharp.Behaviors;
+using SpiceSharp.Components.NonlinearResistorBehaviors;
 
 namespace SpiceSharp.Components
 {
@@ -8,6 +9,14 @@ namespace SpiceSharp.Components
     /// <seealso cref="Component" />
     public class NonlinearResistor : Component
     {
+        static NonlinearResistor()
+        {
+            RegisterBehaviorFactory(typeof(NonlinearResistor), new BehaviorFactoryDictionary
+            {
+                {typeof(LoadBehavior), name => new LoadBehavior(name)}
+            });
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="NonlinearResistor"/> class.
         /// </summary>
@@ -18,9 +27,6 @@ namespace SpiceSharp.Components
         {
             // Add a NonlinearResistorBehaviors.BaseParameters
             ParameterSets.Add(new BaseParameters());
-
-            // Add a NonlinearResistorBehaviors.LoadBehavior factory
-            Behaviors.Add(typeof(LoadBehavior), () => new LoadBehavior(Name));
 
             // Connect the entity
             Connect(nodeA, nodeB);

--- a/SpiceSharpTest/Models/Framework.cs
+++ b/SpiceSharpTest/Models/Framework.cs
@@ -21,6 +21,13 @@ namespace SpiceSharpTest.Models
     {
         protected class NodeMapper : Entity
         {
+            static NodeMapper()
+            {
+                RegisterBehaviorFactory(typeof(NodeMapper), new BehaviorFactoryDictionary
+                {
+                    // {typeof(Mapper), name => new Mapper(_nodes)}
+                });
+            }
             private class Mapper : ExportingBehavior, IBiasingBehavior
             {
                 private List<string> _nodes;
@@ -48,13 +55,11 @@ namespace SpiceSharpTest.Models
             {
                 Priority = 1000;
                 _nodes.AddRange(nodes);
-                Behaviors.Add(typeof(Mapper), () => new Mapper(_nodes));
             }
             public NodeMapper(IEnumerable<string> nodes) : base("Mapper")
             {
                 Priority = 1000;
                 _nodes.AddRange(nodes);
-                Behaviors.Add(typeof(Mapper), () => new Mapper(_nodes));
             }
         }
 

--- a/SpiceSharpTest/Models/Framework.cs
+++ b/SpiceSharpTest/Models/Framework.cs
@@ -25,13 +25,12 @@ namespace SpiceSharpTest.Models
             {
                 RegisterBehaviorFactory(typeof(NodeMapper), new BehaviorFactoryDictionary
                 {
-                    // {typeof(Mapper), name => new Mapper(_nodes)}
+                    {typeof(Mapper), e => new Mapper(((NodeMapper)e)._nodes)}
                 });
             }
             private class Mapper : ExportingBehavior, IBiasingBehavior
             {
                 private List<string> _nodes;
-
                 public Mapper(List<string> nodes) : base("Mapper")
                 {
                     _nodes = nodes;

--- a/SpiceSharpTest/SpiceSharpTest.csproj
+++ b/SpiceSharpTest/SpiceSharpTest.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit3TestAdapter.3.12.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.12.0\build\net35\NUnit3TestAdapter.props')" />
   <Import Project="..\packages\NUnit.3.11.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.11.0\build\NUnit.props')" />
-  <Import Project="..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -116,7 +116,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props'))" />
     <Error Condition="!Exists('..\packages\NUnit.3.11.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.11.0\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.12.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.12.0\build\net35\NUnit3TestAdapter.props'))" />
   </Target>
 </Project>

--- a/SpiceSharpTest/packages.config
+++ b/SpiceSharpTest/packages.config
@@ -8,5 +8,5 @@
   <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.6.0" targetFramework="net452" />
   <package id="NUnit.Extension.TeamCityEventListener" version="1.0.5" targetFramework="net471" />
   <package id="NUnit.Extension.VSProjectLoader" version="3.8.0" targetFramework="net471" />
-  <package id="NUnit3TestAdapter" version="3.10.0" targetFramework="net452" />
+  <package id="NUnit3TestAdapter" version="3.12.0" targetFramework="net471" />
 </packages>


### PR DESCRIPTION
- Real voltage export constructor parameter type changed.
- Behavior factories are now static. They are indexed by their type by the Entity class.
- Behavior factories expect the entity that wishes to create the behavior. This allows differentiation between different types of entities when necessary.
- Circuits can now enumerate entities even when an ordered entity list is not built. May be necessary when copying/cloning circuits or other operations that do not involve simulation.