### PR TITLE
Development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,6 @@
 language: csharp
 solution: SpiceSharp.sln
+
+branches:
+  only:
+  - master

--- a/SpiceSharp/Components/Currentsources/CCCS/CurrentControlledCurrentSource.cs
+++ b/SpiceSharp/Components/Currentsources/CCCS/CurrentControlledCurrentSource.cs
@@ -88,5 +88,18 @@ namespace SpiceSharp.Components
             provider.Add("control", parameters[ControllingName]);
             return provider;
         }
+
+        /// <summary>
+        /// Clone the current controlled current source
+        /// </summary>
+        /// <param name="data">Instance data.</param>
+        /// <returns></returns>
+        public override Entity Clone(InstanceData data)
+        {
+            var clone = (CurrentControlledCurrentSource) base.Clone(data);
+            if (clone.ControllingName != null && data is ComponentInstanceData cid)
+                clone.ControllingName = cid.GenerateIdentifier(clone.ControllingName);
+            return clone;
+        }
     }
 }

--- a/SpiceSharp/Components/RLC/MUT/MutualInductance.cs
+++ b/SpiceSharp/Components/RLC/MUT/MutualInductance.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using SpiceSharp.Attributes;
 using SpiceSharp.Behaviors;
+using SpiceSharp.Circuits;
 using SpiceSharp.Components.MutualInductanceBehaviors;
 
 namespace SpiceSharp.Components
@@ -72,6 +73,24 @@ namespace SpiceSharp.Components
             data.Add("inductor2", behaviors[InductorName2]);
 
             return data;
+        }
+
+        /// <summary>
+        /// Clone the mutual inductance
+        /// </summary>
+        /// <param name="data">Instance data.</param>
+        /// <returns></returns>
+        public override Entity Clone(InstanceData data)
+        {
+            var clone = (MutualInductance) base.Clone(data);
+            if (data is ComponentInstanceData cid)
+            {
+                if (clone.InductorName1 != null)
+                    clone.InductorName1 = cid.GenerateIdentifier(clone.InductorName1);
+                if (clone.InductorName2 != null)
+                    clone.InductorName2 = cid.GenerateIdentifier(clone.InductorName2);
+            }
+            return clone;
         }
     }
 }

--- a/SpiceSharp/Components/Switches/CSW/CurrentSwitch.cs
+++ b/SpiceSharp/Components/Switches/CSW/CurrentSwitch.cs
@@ -89,5 +89,18 @@ namespace SpiceSharp.Components
             provider.Add("control", parameters[ControllingName]);
             return provider;
         }
+
+        /// <summary>
+        /// Clone the current controlled switch
+        /// </summary>
+        /// <param name="data">Instance data.</param>
+        /// <returns></returns>
+        public override Entity Clone(InstanceData data)
+        {
+            var clone = (CurrentControlledCurrentSource)base.Clone(data);
+            if (clone.ControllingName != null && data is ComponentInstanceData cid)
+                clone.ControllingName = cid.GenerateIdentifier(clone.ControllingName);
+            return clone;
+        }
     }
 }

--- a/SpiceSharp/Components/Voltagesources/CCVS/CurrentControlledVoltageSource.cs
+++ b/SpiceSharp/Components/Voltagesources/CCVS/CurrentControlledVoltageSource.cs
@@ -89,5 +89,18 @@ namespace SpiceSharp.Components
 
             return provider;
         }
+
+        /// <summary>
+        /// Clone the current controlled current source
+        /// </summary>
+        /// <param name="data">Instance data.</param>
+        /// <returns></returns>
+        public override Entity Clone(InstanceData data)
+        {
+            var clone = (CurrentControlledCurrentSource)base.Clone(data);
+            if (clone.ControllingName != null && data is ComponentInstanceData cid)
+                clone.ControllingName = cid.GenerateIdentifier(clone.ControllingName);
+            return clone;
+        }
     }
 }

--- a/SpiceSharp/Simulations/Exports/ComplexCurrentExport.cs
+++ b/SpiceSharp/Simulations/Exports/ComplexCurrentExport.cs
@@ -18,12 +18,29 @@ namespace SpiceSharp.Simulations
         public string Source { get; }
 
         /// <summary>
+        /// Check if the simulation is a frequency simulation
+        /// </summary>
+        /// <param name="simulation">The simulation.</param>
+        /// <returns></returns>
+        protected override bool IsValidSimulation(Simulation simulation) => simulation is FrequencySimulation;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RealCurrentExport"/> class.
+        /// </summary>
+        /// <param name="source">The source identifier.</param>
+        /// <exception cref="ArgumentNullException">source</exception>
+        public ComplexCurrentExport(string source)
+        {
+            Source = source.ThrowIfNull(nameof(source));
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="RealCurrentExport"/> class.
         /// </summary>
         /// <param name="simulation">The simulation.</param>
         /// <param name="source">The source identifier.</param>
         /// <exception cref="ArgumentNullException">source</exception>
-        public ComplexCurrentExport(Simulation simulation, string source)
+        public ComplexCurrentExport(FrequencySimulation simulation, string source)
             : base(simulation)
         {
             Source = source.ThrowIfNull(nameof(source));
@@ -37,7 +54,7 @@ namespace SpiceSharp.Simulations
         protected override void Initialize(object sender, EventArgs e)
         {
             // Create our extractor!
-            var state = ((BaseSimulation) Simulation).RealState.ThrowIfNull("real state");
+            var state = ((FrequencySimulation) Simulation).RealState.ThrowIfNull("complex state");
             if (Simulation.EntityBehaviors.TryGetBehaviors(Source, out var ebd))
             {
                 if (ebd.TryGetValue(typeof(Components.VoltageSourceBehaviors.FrequencyBehavior), out var behavior))

--- a/SpiceSharp/Simulations/Exports/ComplexPropertyExport.cs
+++ b/SpiceSharp/Simulations/Exports/ComplexPropertyExport.cs
@@ -38,6 +38,24 @@ namespace SpiceSharp.Simulations
         /// <summary>
         /// Initializes a new instance of the <see cref="ComplexPropertyExport"/> class.
         /// </summary>
+        /// <param name="entityName">The identifier of the entity.</param>
+        /// <param name="propertyName">The name of the property.</param>
+        /// <param name="comparer">The <see cref="IEqualityComparer{T}" /> implementation to use when comparing parameter names, or <c>null</c> to use the default <see cref="EqualityComparer{T}"/>.</param>
+        /// <exception cref="ArgumentNullException">
+        /// entityName
+        /// or
+        /// propertyName
+        /// </exception>
+        public ComplexPropertyExport(string entityName, string propertyName, IEqualityComparer<string> comparer = null)
+        {
+            EntityName = entityName.ThrowIfNull(nameof(entityName));
+            PropertyName = propertyName.ThrowIfNull(nameof(propertyName));
+            Comparer = comparer ?? EqualityComparer<string>.Default;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ComplexPropertyExport"/> class.
+        /// </summary>
         /// <param name="simulation">The simulation.</param>
         /// <param name="entityName">The identifier of the entity.</param>
         /// <param name="propertyName">The name of the property.</param>

--- a/SpiceSharp/Simulations/Exports/ComplexVoltageExport.cs
+++ b/SpiceSharp/Simulations/Exports/ComplexVoltageExport.cs
@@ -56,6 +56,24 @@ namespace SpiceSharp.Simulations
         }
 
         /// <summary>
+        /// Check if the simulation is a <see cref="FrequencySimulation" />.
+        /// </summary>
+        /// <param name="simulation">The simulation.</param>
+        /// <returns></returns>
+        protected override bool IsValidSimulation(Simulation simulation) => simulation is FrequencySimulation;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ComplexVoltageExport"/> class.
+        /// </summary>
+        /// <param name="posNode">The node identifier.</param>
+        /// <exception cref="ArgumentNullException">posNode</exception>
+        public ComplexVoltageExport(string posNode)
+        {
+            PosNode = posNode.ThrowIfNull(nameof(posNode));
+            NegNode = null;
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ComplexVoltageExport"/> class.
         /// </summary>
         /// <param name="simulation">The simulation.</param>
@@ -71,11 +89,23 @@ namespace SpiceSharp.Simulations
         /// <summary>
         /// Initializes a new instance of the <see cref="ComplexVoltageExport"/> class.
         /// </summary>
+        /// <param name="posNode">The positive node identifier.</param>
+        /// <param name="negNode">The negative node identifier.</param>
+        /// <exception cref="ArgumentNullException">posNode</exception>
+        public ComplexVoltageExport(string posNode, string negNode)
+        {
+            PosNode = posNode.ThrowIfNull(nameof(posNode));
+            NegNode = negNode;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ComplexVoltageExport"/> class.
+        /// </summary>
         /// <param name="simulation">The simulation.</param>
         /// <param name="posNode">The positive node identifier.</param>
         /// <param name="negNode">The negative node identifier.</param>
         /// <exception cref="ArgumentNullException">posNode</exception>
-        public ComplexVoltageExport(Simulation simulation, string posNode, string negNode)
+        public ComplexVoltageExport(FrequencySimulation simulation, string posNode, string negNode)
             : base(simulation)
         {
             PosNode = posNode.ThrowIfNull(nameof(posNode));

--- a/SpiceSharp/Simulations/Exports/Export.cs
+++ b/SpiceSharp/Simulations/Exports/Export.cs
@@ -38,7 +38,7 @@ namespace SpiceSharp.Simulations
         /// <value>
         /// The simulation.
         /// </value>
-        protected Simulation Simulation { get; }
+        protected Simulation Simulation { get; private set; }
 
         /// <summary>
         /// Gets the current value from the simulation.
@@ -72,6 +72,18 @@ namespace SpiceSharp.Simulations
         /// <exception cref="ArgumentNullException">simulation</exception>
         protected Export(Simulation simulation)
         {
+            Simulation = simulation.ThrowIfNull(nameof(simulation));
+            simulation.AfterSetup += Initialize;
+            simulation.BeforeUnsetup += Finalize;
+        }
+
+        /// <summary>
+        /// Switch the simulation this export should use.
+        /// </summary>
+        /// <param name="simulation">The simulation.</param>
+        public virtual void Switch(Simulation simulation)
+        {
+            Destroy();
             Simulation = simulation.ThrowIfNull(nameof(simulation));
             simulation.AfterSetup += Initialize;
             simulation.BeforeUnsetup += Finalize;

--- a/SpiceSharp/Simulations/Exports/GenericExport.cs
+++ b/SpiceSharp/Simulations/Exports/GenericExport.cs
@@ -17,6 +17,15 @@ namespace SpiceSharp.Simulations
         /// <summary>
         /// Initializes a new instance of the <see cref="GenericExport{T}"/> class.
         /// </summary>
+        /// <param name="extractor">The function for extracting information.</param>
+        public GenericExport(Func<T> extractor)
+        {
+            _myExtractor = extractor.ThrowIfNull(nameof(extractor));
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GenericExport{T}"/> class.
+        /// </summary>
         /// <param name="simulation">The simulation.</param>
         /// <param name="extractor">The function for extracting information.</param>
         public GenericExport(Simulation simulation, Func<T> extractor)

--- a/SpiceSharp/Simulations/Exports/InputNoiseDensityExport.cs
+++ b/SpiceSharp/Simulations/Exports/InputNoiseDensityExport.cs
@@ -8,6 +8,21 @@ namespace SpiceSharp.Simulations
     /// <seealso cref="Export{T}" />
     public class InputNoiseDensityExport : Export<double>
     {
+
+        /// <summary>
+        /// Check if the simulation is a <see cref="Noise"/> simulation.
+        /// </summary>
+        /// <param name="simulation"></param>
+        /// <returns></returns>
+        protected override bool IsValidSimulation(Simulation simulation) => simulation is Noise;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InputNoiseDensityExport"/> class.
+        /// </summary>
+        public InputNoiseDensityExport()
+        {
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="InputNoiseDensityExport"/> class.
         /// </summary>

--- a/SpiceSharp/Simulations/Exports/InputNoiseDensityExport.cs
+++ b/SpiceSharp/Simulations/Exports/InputNoiseDensityExport.cs
@@ -8,7 +8,6 @@ namespace SpiceSharp.Simulations
     /// <seealso cref="Export{T}" />
     public class InputNoiseDensityExport : Export<double>
     {
-
         /// <summary>
         /// Check if the simulation is a <see cref="Noise"/> simulation.
         /// </summary>

--- a/SpiceSharp/Simulations/Exports/OutputNoiseDensityExport.cs
+++ b/SpiceSharp/Simulations/Exports/OutputNoiseDensityExport.cs
@@ -9,6 +9,13 @@ namespace SpiceSharp.Simulations
     public class OutputNoiseDensityExport : Export<double>
     {
         /// <summary>
+        /// Check if the simulation is a <see cref="Noise"/> simulation.
+        /// </summary>
+        /// <param name="simulation">The simulation.</param>
+        /// <returns></returns>
+        protected override bool IsValidSimulation(Simulation simulation) => simulation is Noise;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="OutputNoiseDensityExport"/> class.
         /// </summary>
         /// <param name="noise">The noise analysis.</param>

--- a/SpiceSharp/Simulations/Exports/RealCurrentExport.cs
+++ b/SpiceSharp/Simulations/Exports/RealCurrentExport.cs
@@ -17,12 +17,30 @@ namespace SpiceSharp.Simulations
         public string Source { get; }
 
         /// <summary>
+        /// Check if the simulation is a base simulation.
+        /// </summary>
+        /// <param name="simulation"></param>
+        /// <returns></returns>
+        protected override bool IsValidSimulation(Simulation simulation) => simulation is BaseSimulation;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="RealCurrentExport"/> class.
         /// </summary>
         /// <param name="simulation">The simulation.</param>
         /// <param name="source">The source identifier.</param>
         /// <exception cref="ArgumentNullException">source</exception>
-        public RealCurrentExport(Simulation simulation, string source)
+        public RealCurrentExport(string source)
+        {
+            Source = source.ThrowIfNull(nameof(source));
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RealCurrentExport"/> class.
+        /// </summary>
+        /// <param name="simulation">The simulation.</param>
+        /// <param name="source">The source identifier.</param>
+        /// <exception cref="ArgumentNullException">source</exception>
+        public RealCurrentExport(BaseSimulation simulation, string source)
             : base(simulation)
         {
             Source = source.ThrowIfNull(nameof(source));

--- a/SpiceSharp/Simulations/Exports/RealPropertyExport.cs
+++ b/SpiceSharp/Simulations/Exports/RealPropertyExport.cs
@@ -37,6 +37,24 @@ namespace SpiceSharp.Simulations
         /// <summary>
         /// Initializes a new instance of the <see cref="RealPropertyExport"/> class.
         /// </summary>
+        /// <param name="entityName">The identifier of the entity.</param>
+        /// <param name="propertyName">The name of the property.</param>
+        /// <param name="comparer">The <see cref="IEqualityComparer{T}" /> implementation to use when comparing parameter names, or <c>null</c> to use the default <see cref="EqualityComparer{T}"/>.</param>
+        /// <exception cref="ArgumentNullException">
+        /// entityName
+        /// or
+        /// propertyName
+        /// </exception>
+        public RealPropertyExport(string entityName, string propertyName, IEqualityComparer<string> comparer = null)
+        {
+            EntityName = entityName.ThrowIfNull(nameof(entityName));
+            PropertyName = propertyName.ThrowIfNull(nameof(propertyName));
+            Comparer = comparer ?? EqualityComparer<string>.Default;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RealPropertyExport"/> class.
+        /// </summary>
         /// <param name="simulation">The simulation.</param>
         /// <param name="entityName">The identifier of the entity.</param>
         /// <param name="propertyName">The name of the property.</param>

--- a/SpiceSharp/Simulations/Exports/RealVoltageExport.cs
+++ b/SpiceSharp/Simulations/Exports/RealVoltageExport.cs
@@ -25,12 +25,30 @@ namespace SpiceSharp.Simulations
         public string NegNode { get; }
 
         /// <summary>
+        /// Check if the simulation is a <see cref="BaseSimulation"/>.
+        /// </summary>
+        /// <param name="simulation"></param>
+        /// <returns></returns>
+        protected override bool IsValidSimulation(Simulation simulation) => simulation is BaseSimulation;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RealVoltageExport"/> class.
+        /// </summary>
+        /// <param name="posNode">The node identifier.</param>
+        /// <exception cref="ArgumentNullException">posNode</exception>
+        public RealVoltageExport(string posNode)
+        {
+            PosNode = posNode.ThrowIfNull(nameof(posNode));
+            NegNode = null;
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="RealVoltageExport"/> class.
         /// </summary>
         /// <param name="simulation">The simulation.</param>
         /// <param name="posNode">The node identifier.</param>
         /// <exception cref="ArgumentNullException">posNode</exception>
-        public RealVoltageExport(Simulation simulation, string posNode)
+        public RealVoltageExport(BaseSimulation simulation, string posNode)
             : base(simulation)
         {
             PosNode = posNode.ThrowIfNull(nameof(posNode));
@@ -44,7 +62,7 @@ namespace SpiceSharp.Simulations
         /// <param name="posNode">The positive node identifier.</param>
         /// <param name="negNode">The negative node identifier.</param>
         /// <exception cref="ArgumentNullException">posNode</exception>
-        public RealVoltageExport(Simulation simulation, string posNode, string negNode)
+        public RealVoltageExport(BaseSimulation simulation, string posNode, string negNode)
             : base(simulation)
         {
             PosNode = posNode.ThrowIfNull(nameof(posNode));

--- a/SpiceSharp/SpiceSharp.csproj
+++ b/SpiceSharp/SpiceSharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.5;netstandard2.0;net45;netcoreapp2.0</TargetFrameworks>
-    <Version>2.7.1</Version>
+    <Version>2.7.2</Version>
     <Authors>Sven Boulanger</Authors>
     <Description>Spice# is a circuit simulator based on and improved from Spice 3f5 by Berkeley. The framework allows custom components and simulations to be added.</Description>
     <PackageProjectUrl>https://github.com/SpiceSharp/SpiceSharp</PackageProjectUrl>
@@ -10,12 +10,12 @@
     <RepositoryUrl>https://github.com/SpiceSharp/SpiceSharp</RepositoryUrl>
     <PackageTags>circuit electronics netlist parser spice simulator simulation ode solver design</PackageTags>
     <PackageIconUrl>https://raw.githubusercontent.com/SpiceSharp/SpiceSharp/master/api/images/logo_full.svg?sanitize=true</PackageIconUrl>
-    <AssemblyVersion>2.7.1.0</AssemblyVersion>
+    <AssemblyVersion>2.7.2.0</AssemblyVersion>
     <PackageReleaseNotes>Refer to the GitHub release for release notes</PackageReleaseNotes>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company />
     <NeutralLanguage>en-001</NeutralLanguage>
-    <FileVersion>2.7.1.0</FileVersion>
+    <FileVersion>2.7.2.0</FileVersion>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/SpiceSharpTest/Simulations/TransientTests.cs
+++ b/SpiceSharpTest/Simulations/TransientTests.cs
@@ -324,9 +324,9 @@ namespace SpiceSharpTest.Simulations
             sim1.Run(ckt);
 
             // Switch exports
-            vexport.Switch(sim2);
-            iexport.Switch(sim2);
-            pexport.Switch(sim2);
+            vexport.Simulation = sim2;
+            iexport.Simulation = sim2;
+            pexport.Simulation = sim2;
 
             sim2.Run(ckt);
         }

--- a/SpiceSharpTest/Simulations/TransientTests.cs
+++ b/SpiceSharpTest/Simulations/TransientTests.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using NUnit.Framework;
 using SpiceSharp;
-using SpiceSharp.Circuits;
 using SpiceSharp.Components;
 using SpiceSharp.IntegrationMethods;
 using SpiceSharp.Simulations;
@@ -55,6 +53,8 @@ namespace SpiceSharpTest.Simulations
 
             // Create the transient analysis
             var tran = new Transient("tran 1", 1.0, 10.0);
+            // TODO: review this test
+            // tran.Configurations.Get<TimeConfiguration>().Method = new Gear();
             tran.ExportSimulationData += (sender, args) => { Assert.AreEqual(args.GetVoltage("out"), 10.0, 1e-12); };
             tran.Run(ckt);
 
@@ -290,6 +290,45 @@ namespace SpiceSharpTest.Simulations
             // Calculate the operating point
             var tran = new Transient("tran", 1e-9, 10e-6);
             tran.Run(ckt);
+        }
+
+        [Test]
+        public void When_ExportSwitch_Expect_Reference()
+        {
+            var ckt = new Circuit(
+                new VoltageSource("V1", "in", "0", new Sine(1, 1, 10)),
+                new Resistor("R1", "in", "out", 1e3),
+                new Resistor("R2", "out", "0", 1e3));
+
+            var sim1 = new DC("dc", "V1", 0, 2, 0.2);
+            var sim2 = new Transient("tran", 1e-3, 0.5);
+
+            var vexport = new RealVoltageExport(sim1, "out");
+            var iexport = new RealCurrentExport(sim1, "V1");
+            var pexport = new RealPropertyExport(sim1, "R1", "p");
+            sim1.ExportSimulationData += (sender, e) =>
+            {
+                var input = e.GetVoltage("in");
+                Assert.AreEqual(input * 0.5, vexport.Value, 1e-9);
+                Assert.AreEqual(-input / 2.0e3, iexport.Value, 1e-9);
+                Assert.AreEqual(input * input / 4.0 / 1.0e3, pexport.Value, 1e-9);
+            };
+            sim2.ExportSimulationData += (sender, e) =>
+            {
+                var input = e.GetVoltage("in");
+                Assert.AreEqual(Math.Sin(2 * Math.PI * 10 * e.Time) + 1.0, input, 1e-9);
+                Assert.AreEqual(input * 0.5, vexport.Value, 1e-9);
+                Assert.AreEqual(-input / 2.0e3, iexport.Value, 1e-9);
+                Assert.AreEqual(input * input / 4.0 / 1.0e3, pexport.Value, 1e-9);
+            };
+            sim1.Run(ckt);
+
+            // Switch exports
+            vexport.Switch(sim2);
+            iexport.Switch(sim2);
+            pexport.Switch(sim2);
+
+            sim2.Run(ckt);
         }
     }
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,6 @@ environment:
 branches:
   only:
     - master
-    - development
 
 before_build:
   - nuget restore


### PR DESCRIPTION
- Entities referencing other entities did not correctly implement `Clone(InstanceData)`.
- Allow `Export<T>` to allow switching simulations.