### PR TITLE
Development

### DIFF
--- a/SpiceSharp/Circuits/EntityCollection.cs
+++ b/SpiceSharp/Circuits/EntityCollection.cs
@@ -29,33 +29,6 @@ namespace SpiceSharp.Circuits
         public event EventHandler<EntityEventArgs> EntityRemoved;
 
         /// <summary>
-        /// Gets the comparer for entity identifiers.
-        /// </summary>
-        /// <value>
-        /// The comparer.
-        /// </value>
-        public IEqualityComparer<string> Comparer => _entities.Comparer;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="EntityCollection"/> class.
-        /// </summary>
-        public EntityCollection()
-        {
-            _lock = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
-            _entities = new Dictionary<string, Entity>();
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="EntityCollection"/> class.
-        /// </summary>
-        /// <param name="comparer">The <see cref="IEqualityComparer{T}" /> implementation to use when comparing entity names, or <c>null</c> to use the default <see cref="EqualityComparer{T}"/>.</param>
-        public EntityCollection(IEqualityComparer<string> comparer)
-        {
-            _lock = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
-            _entities = new Dictionary<string, Entity>(comparer);
-        }
-
-        /// <summary>
         /// Search for an entity by its string.
         /// </summary>
         /// <value>
@@ -83,6 +56,14 @@ namespace SpiceSharp.Circuits
         }
 
         /// <summary>
+        /// Gets the comparer for entity identifiers.
+        /// </summary>
+        /// <value>
+        /// The comparer.
+        /// </value>
+        public IEqualityComparer<string> Comparer => _entities.Comparer;
+
+        /// <summary>
         /// The number of entities.
         /// </summary>
         public int Count
@@ -101,11 +82,44 @@ namespace SpiceSharp.Circuits
             }
         }
 
-        public bool IsSynchronized => throw new NotImplementedException();
+        /// <summary>
+        /// Enumerates the names of all entities in the collection.
+        /// </summary>
+        public IEnumerable<string> Keys => _entities.Keys;
 
-        public object SyncRoot => throw new NotImplementedException();
+        /// <summary>
+        /// Gets a value indicating whether access to the <see cref="ICollection{T}</see> is synchronized (thread safe).
+        /// </summary>
+        public bool IsSynchronized => true;
 
-        public bool IsReadOnly => throw new NotImplementedException();
+        /// <summary>
+        /// Gets an object that can be used to synchronize access to the <see cref="ICollection{T}"/>.
+        /// </summary>
+        public object SyncRoot => this;
+
+        /// <summary>
+        /// Gets a value indicating whether the <see cref="ICollection{T}"/> is read-only.
+        /// </summary>
+        public bool IsReadOnly => false;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EntityCollection"/> class.
+        /// </summary>
+        public EntityCollection()
+        {
+            _lock = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
+            _entities = new Dictionary<string, Entity>();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EntityCollection"/> class.
+        /// </summary>
+        /// <param name="comparer">The <see cref="IEqualityComparer{T}" /> implementation to use when comparing entity names, or <c>null</c> to use the default <see cref="EqualityComparer{T}"/>.</param>
+        public EntityCollection(IEqualityComparer<string> comparer)
+        {
+            _lock = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
+            _entities = new Dictionary<string, Entity>(comparer);
+        }
 
         /// <summary>
         /// Clear all entities in the collection.

--- a/SpiceSharp/Simulations/Exports/ComplexCurrentExport.cs
+++ b/SpiceSharp/Simulations/Exports/ComplexCurrentExport.cs
@@ -18,21 +18,16 @@ namespace SpiceSharp.Simulations
         public string Source { get; }
 
         /// <summary>
+        /// Gets the index in the of the current variable.
+        /// </summary>
+        public int Index { get; private set; }
+
+        /// <summary>
         /// Check if the simulation is a frequency simulation
         /// </summary>
         /// <param name="simulation">The simulation.</param>
         /// <returns></returns>
         protected override bool IsValidSimulation(Simulation simulation) => simulation is FrequencySimulation;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RealCurrentExport"/> class.
-        /// </summary>
-        /// <param name="source">The source identifier.</param>
-        /// <exception cref="ArgumentNullException">source</exception>
-        public ComplexCurrentExport(string source)
-        {
-            Source = source.ThrowIfNull(nameof(source));
-        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RealCurrentExport"/> class.
@@ -44,13 +39,14 @@ namespace SpiceSharp.Simulations
             : base(simulation)
         {
             Source = source.ThrowIfNull(nameof(source));
+            Index = -1;
         }
 
         /// <summary>
         /// Initializes the export.
         /// </summary>
         /// <param name="sender">The object (simulation) sending the event.</param>
-        /// <param name="e">The <see cref="T:System.EventArgs" /> instance containing the event data.</param>
+        /// <param name="e">The <see cref="EventArgs" /> instance containing the event data.</param>
         protected override void Initialize(object sender, EventArgs e)
         {
             // Create our extractor!
@@ -59,10 +55,21 @@ namespace SpiceSharp.Simulations
             {
                 if (ebd.TryGetValue(typeof(Components.VoltageSourceBehaviors.FrequencyBehavior), out var behavior))
                 {
-                    var index = ((Components.VoltageSourceBehaviors.FrequencyBehavior) behavior).BranchEq;
-                    Extractor = () => state.Solution[index];
+                    Index = ((Components.VoltageSourceBehaviors.FrequencyBehavior) behavior).BranchEq;
+                    Extractor = () => state.Solution[Index];
                 }
             }
+        }
+
+        /// <summary>
+        /// Finalizes the export.
+        /// </summary>
+        /// <param name="sender">The object (simulation) sending the event</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected override void Finalize(object sender, EventArgs e)
+        {
+            base.Finalize(sender, e);
+            Index = -1;
         }
     }
 }

--- a/SpiceSharp/Simulations/Exports/ComplexPropertyExport.cs
+++ b/SpiceSharp/Simulations/Exports/ComplexPropertyExport.cs
@@ -38,24 +38,6 @@ namespace SpiceSharp.Simulations
         /// <summary>
         /// Initializes a new instance of the <see cref="ComplexPropertyExport"/> class.
         /// </summary>
-        /// <param name="entityName">The identifier of the entity.</param>
-        /// <param name="propertyName">The name of the property.</param>
-        /// <param name="comparer">The <see cref="IEqualityComparer{T}" /> implementation to use when comparing parameter names, or <c>null</c> to use the default <see cref="EqualityComparer{T}"/>.</param>
-        /// <exception cref="ArgumentNullException">
-        /// entityName
-        /// or
-        /// propertyName
-        /// </exception>
-        public ComplexPropertyExport(string entityName, string propertyName, IEqualityComparer<string> comparer = null)
-        {
-            EntityName = entityName.ThrowIfNull(nameof(entityName));
-            PropertyName = propertyName.ThrowIfNull(nameof(propertyName));
-            Comparer = comparer ?? EqualityComparer<string>.Default;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ComplexPropertyExport"/> class.
-        /// </summary>
         /// <param name="simulation">The simulation.</param>
         /// <param name="entityName">The identifier of the entity.</param>
         /// <param name="propertyName">The name of the property.</param>

--- a/SpiceSharp/Simulations/Exports/Export.cs
+++ b/SpiceSharp/Simulations/Exports/Export.cs
@@ -96,14 +96,6 @@ namespace SpiceSharp.Simulations
         /// <summary>
         /// Initializes a new instance of the <see cref="Export{T}"/> class.
         /// </summary>
-        protected Export()
-        {
-            Simulation = null;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Export{T}"/> class.
-        /// </summary>
         /// <param name="simulation">The simulation.</param>
         /// <exception cref="ArgumentNullException">simulation</exception>
         protected Export(Simulation simulation)

--- a/SpiceSharp/Simulations/Exports/GenericExport.cs
+++ b/SpiceSharp/Simulations/Exports/GenericExport.cs
@@ -17,15 +17,6 @@ namespace SpiceSharp.Simulations
         /// <summary>
         /// Initializes a new instance of the <see cref="GenericExport{T}"/> class.
         /// </summary>
-        /// <param name="extractor">The function for extracting information.</param>
-        public GenericExport(Func<T> extractor)
-        {
-            _myExtractor = extractor.ThrowIfNull(nameof(extractor));
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="GenericExport{T}"/> class.
-        /// </summary>
         /// <param name="simulation">The simulation.</param>
         /// <param name="extractor">The function for extracting information.</param>
         public GenericExport(Simulation simulation, Func<T> extractor)

--- a/SpiceSharp/Simulations/Exports/InputNoiseDensityExport.cs
+++ b/SpiceSharp/Simulations/Exports/InputNoiseDensityExport.cs
@@ -18,13 +18,6 @@ namespace SpiceSharp.Simulations
         /// <summary>
         /// Initializes a new instance of the <see cref="InputNoiseDensityExport"/> class.
         /// </summary>
-        public InputNoiseDensityExport()
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="InputNoiseDensityExport"/> class.
-        /// </summary>
         /// <param name="noise">The noise analysis.</param>
         public InputNoiseDensityExport(Noise noise)
             : base(noise)

--- a/SpiceSharp/Simulations/Exports/RealCurrentExport.cs
+++ b/SpiceSharp/Simulations/Exports/RealCurrentExport.cs
@@ -17,6 +17,11 @@ namespace SpiceSharp.Simulations
         public string Source { get; }
 
         /// <summary>
+        /// Gets the index of the variable in the solver.
+        /// </summary>
+        public int Index { get; private set; }
+
+        /// <summary>
         /// Check if the simulation is a base simulation.
         /// </summary>
         /// <param name="simulation"></param>
@@ -29,28 +34,18 @@ namespace SpiceSharp.Simulations
         /// <param name="simulation">The simulation.</param>
         /// <param name="source">The source identifier.</param>
         /// <exception cref="ArgumentNullException">source</exception>
-        public RealCurrentExport(string source)
-        {
-            Source = source.ThrowIfNull(nameof(source));
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RealCurrentExport"/> class.
-        /// </summary>
-        /// <param name="simulation">The simulation.</param>
-        /// <param name="source">The source identifier.</param>
-        /// <exception cref="ArgumentNullException">source</exception>
         public RealCurrentExport(BaseSimulation simulation, string source)
             : base(simulation)
         {
             Source = source.ThrowIfNull(nameof(source));
+            Index = -1;
         }
 
         /// <summary>
         /// Initializes the export.
         /// </summary>
         /// <param name="sender">The object (simulation) sending the event.</param>
-        /// <param name="e">The <see cref="T:System.EventArgs" /> instance containing the event data.</param>
+        /// <param name="e">The <see cref="EventArgs" /> instance containing the event data.</param>
         protected override void Initialize(object sender, EventArgs e)
         {
             // Create our extractor!
@@ -59,10 +54,21 @@ namespace SpiceSharp.Simulations
             {
                 if (ebd.TryGetValue(typeof(Components.VoltageSourceBehaviors.BiasingBehavior), out var behavior))
                 {
-                    var index = ((Components.VoltageSourceBehaviors.BiasingBehavior) behavior).BranchEq;
-                    Extractor = () => state.Solution[index];
+                    Index = ((Components.VoltageSourceBehaviors.BiasingBehavior) behavior).BranchEq;
+                    Extractor = () => state.Solution[Index];
                 }
             }
+        }
+
+        /// <summary>
+        /// Finalizes the export.
+        /// </summary>
+        /// <param name="sender">The object (simulation) sending the event.</param>
+        /// <param name="e">the <see cref="EventArgs"/> instance containing the event data.</param>
+        protected override void Finalize(object sender, EventArgs e)
+        {
+            base.Finalize(sender, e);
+            Index = -1;
         }
     }
 }

--- a/SpiceSharp/Simulations/Exports/RealPropertyExport.cs
+++ b/SpiceSharp/Simulations/Exports/RealPropertyExport.cs
@@ -37,24 +37,6 @@ namespace SpiceSharp.Simulations
         /// <summary>
         /// Initializes a new instance of the <see cref="RealPropertyExport"/> class.
         /// </summary>
-        /// <param name="entityName">The identifier of the entity.</param>
-        /// <param name="propertyName">The name of the property.</param>
-        /// <param name="comparer">The <see cref="IEqualityComparer{T}" /> implementation to use when comparing parameter names, or <c>null</c> to use the default <see cref="EqualityComparer{T}"/>.</param>
-        /// <exception cref="ArgumentNullException">
-        /// entityName
-        /// or
-        /// propertyName
-        /// </exception>
-        public RealPropertyExport(string entityName, string propertyName, IEqualityComparer<string> comparer = null)
-        {
-            EntityName = entityName.ThrowIfNull(nameof(entityName));
-            PropertyName = propertyName.ThrowIfNull(nameof(propertyName));
-            Comparer = comparer ?? EqualityComparer<string>.Default;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RealPropertyExport"/> class.
-        /// </summary>
         /// <param name="simulation">The simulation.</param>
         /// <param name="entityName">The identifier of the entity.</param>
         /// <param name="propertyName">The name of the property.</param>

--- a/SpiceSharp/Simulations/Exports/RealVoltageExport.cs
+++ b/SpiceSharp/Simulations/Exports/RealVoltageExport.cs
@@ -17,12 +17,22 @@ namespace SpiceSharp.Simulations
         public string PosNode { get; }
 
         /// <summary>
+        /// Gets the index of the positive node variable.
+        /// </summary>
+        public int PosIndex { get; private set; }
+
+        /// <summary>
         /// Gets the identifier of the negative node.
         /// </summary>
         /// <value>
         /// The negative node identifier.
         /// </value>
         public string NegNode { get; }
+
+        /// <summary>
+        /// gets the index of the negative node variable.
+        /// </summary>
+        public int NegIndex { get; private set; }
 
         /// <summary>
         /// Check if the simulation is a <see cref="BaseSimulation"/>.
@@ -34,17 +44,6 @@ namespace SpiceSharp.Simulations
         /// <summary>
         /// Initializes a new instance of the <see cref="RealVoltageExport"/> class.
         /// </summary>
-        /// <param name="posNode">The node identifier.</param>
-        /// <exception cref="ArgumentNullException">posNode</exception>
-        public RealVoltageExport(string posNode)
-        {
-            PosNode = posNode.ThrowIfNull(nameof(posNode));
-            NegNode = null;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RealVoltageExport"/> class.
-        /// </summary>
         /// <param name="simulation">The simulation.</param>
         /// <param name="posNode">The node identifier.</param>
         /// <exception cref="ArgumentNullException">posNode</exception>
@@ -52,7 +51,9 @@ namespace SpiceSharp.Simulations
             : base(simulation)
         {
             PosNode = posNode.ThrowIfNull(nameof(posNode));
+            PosIndex = -1;
             NegNode = null;
+            NegIndex = -1;
         }
 
         /// <summary>
@@ -66,14 +67,16 @@ namespace SpiceSharp.Simulations
             : base(simulation)
         {
             PosNode = posNode.ThrowIfNull(nameof(posNode));
+            PosIndex = -1;
             NegNode = negNode;
+            NegIndex = -1;
         }
 
         /// <summary>
         /// Initializes the export.
         /// </summary>
         /// <param name="sender">The object (simulation) sending the event.</param>
-        /// <param name="e">The <see cref="T:System.EventArgs" /> instance containing the event data.</param>
+        /// <param name="e">The <see cref="EventArgs" /> instance containing the event data.</param>
         protected override void Initialize(object sender, EventArgs e)
         {
             // Create our extractor!
@@ -81,14 +84,31 @@ namespace SpiceSharp.Simulations
             if (Simulation.Variables.TryGetNode(PosNode, out var posNode))
             {
                 var posNodeIndex = posNode.Index;
+                PosIndex = posNodeIndex;
                 if (NegNode == null)
+                {
                     Extractor = () => state.Solution[posNodeIndex];
+                    NegIndex = 0;
+                }
                 else if (Simulation.Variables.TryGetNode(NegNode, out var negNode))
                 {
                     var negNodeIndex = negNode.Index;
                     Extractor = () => state.Solution[posNodeIndex] - state.Solution[negNodeIndex];
+                    NegIndex = negNodeIndex;
                 }
             }
+        }
+
+        /// <summary>
+        /// Finalizes the export.
+        /// </summary>
+        /// <param name="sender">The object (simulation) sending the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected override void Finalize(object sender, EventArgs e)
+        {
+            base.Finalize(sender, e);
+            PosIndex = -1;
+            NegIndex = -1;
         }
     }
 }

--- a/SpiceSharp/Simulations/Variables/VariableEventArgs.cs
+++ b/SpiceSharp/Simulations/Variables/VariableEventArgs.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace SpiceSharp.Simulations
+{
+    /// <summary>
+    /// Arguments for events that pass a <see cref="Variable"/>.
+    /// </summary>
+    public class VariableEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Gets the variable.
+        /// </summary>
+        public Variable Variable { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VariableEventArgs"/> class.
+        /// </summary>
+        /// <param name="variable">The variable.</param>
+        public VariableEventArgs(Variable variable)
+        {
+            Variable = variable;
+        }
+    }
+}

--- a/SpiceSharp/Simulations/Variables/VariableSet.cs
+++ b/SpiceSharp/Simulations/Variables/VariableSet.cs
@@ -123,7 +123,10 @@ namespace SpiceSharp.Simulations
             var node = new Variable(id, type, _unknowns.Count + 1);
             _unknowns.Add(node);
             _map.Add(id, node);
-            OnVariableAdded(node);
+
+            // Call the event
+            var args = new VariableEventArgs(node);
+            OnVariableAdded(args);
             return node;
         }
 
@@ -167,7 +170,10 @@ namespace SpiceSharp.Simulations
             var index = _unknowns.Count + 1;
             var node = new Variable(id, type, index);
             _unknowns.Add(node);
-            OnVariableAdded(node);
+
+            // Call the event
+            var args = new VariableEventArgs(node);
+            OnVariableAdded(args);
             return node;
         }
 
@@ -297,6 +303,6 @@ namespace SpiceSharp.Simulations
         /// Method that calls the <see cref="VariableAdded"/> event.
         /// </summary>
         /// <param name="variable"></param>
-        protected virtual void OnVariableAdded(Variable variable) => VariableAdded?.Invoke(this, variable);
+        protected virtual void OnVariableAdded(VariableEventArgs args) => VariableAdded?.Invoke(this, args);
     }
 }

--- a/SpiceSharp/Simulations/Variables/VariableSet.cs
+++ b/SpiceSharp/Simulations/Variables/VariableSet.cs
@@ -8,7 +8,7 @@ namespace SpiceSharp.Simulations
     /// <summary>
     /// Contains and manages circuit nodes.
     /// </summary>
-    public class VariableSet : IEnumerable<Variable>
+    public class VariableSet : IEnumerable<Variable>, ICollection, IReadOnlyCollection<Variable>
     {
         /// <summary>
         /// Private variables
@@ -16,6 +16,11 @@ namespace SpiceSharp.Simulations
         private readonly List<Variable> _unknowns = new List<Variable>();
         private readonly Dictionary<string, Variable> _map;
         private bool _locked;
+
+        /// <summary>
+        /// Event that is called when a variable is added to the set.
+        /// </summary>
+        public event EventHandler<VariableEventArgs> VariableAdded;
 
         /// <summary>
         /// Gets the ground node.
@@ -46,6 +51,21 @@ namespace SpiceSharp.Simulations
         /// Enumerate all variable names in the set.
         /// </summary>
         public IEnumerable<string> Keys => _map.Keys;
+
+        /// <summary>
+        /// Gets a value indicating whether access to the <see cref="ICollection{T}</see> is synchronized (thread safe).
+        /// </summary>
+        public bool IsSynchronized => true;
+
+        /// <summary>
+        /// Gets an object that can be used to synchronize access to the <see cref="ICollection{T}"/>.
+        /// </summary>
+        public object SyncRoot => this;
+
+        /// <summary>
+        /// Gets a value indicating whether the <see cref="ICollection{T}"/> is read-only.
+        /// </summary>
+        public bool IsReadOnly => false;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="VariableSet"/> class.
@@ -103,6 +123,7 @@ namespace SpiceSharp.Simulations
             var node = new Variable(id, type, _unknowns.Count + 1);
             _unknowns.Add(node);
             _map.Add(id, node);
+            OnVariableAdded(node);
             return node;
         }
 
@@ -146,6 +167,7 @@ namespace SpiceSharp.Simulations
             var index = _unknowns.Count + 1;
             var node = new Variable(id, type, index);
             _unknowns.Add(node);
+            OnVariableAdded(node);
             return node;
         }
 
@@ -253,5 +275,28 @@ namespace SpiceSharp.Simulations
         /// An <see cref="IEnumerator" /> object that can be used to iterate through the collection.
         /// </returns>
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        /// <summary>
+        /// Copy the elements to an array.
+        /// </summary>
+        /// <param name="array">The array.</param>
+        /// <param name="index">The starting index.</param>
+        void ICollection.CopyTo(Array array, int index)
+        {
+            array.ThrowIfNull(nameof(array));
+            if (index < 0)
+                throw new ArgumentOutOfRangeException(nameof(index));
+            if (array.Length < index + Count)
+                throw new ArgumentException("Not enough elements in the array");
+
+            foreach (var item in _unknowns)
+                array.SetValue(item, index++);
+        }
+
+        /// <summary>
+        /// Method that calls the <see cref="VariableAdded"/> event.
+        /// </summary>
+        /// <param name="variable"></param>
+        protected virtual void OnVariableAdded(Variable variable) => VariableAdded?.Invoke(this, variable);
     }
 }

--- a/SpiceSharp/Simulations/Variables/VariableSet.cs
+++ b/SpiceSharp/Simulations/Variables/VariableSet.cs
@@ -23,6 +23,31 @@ namespace SpiceSharp.Simulations
         public Variable Ground { get; }
 
         /// <summary>
+        /// Gets the <see cref="IEqualityComparer{T}"/> that is used to determine equality of keys.
+        /// </summary>
+        public IEqualityComparer<string> Comparer => _map.Comparer;
+
+        /// <summary>
+        /// Gets the <see cref="Variable"/> at the specified index.
+        /// </summary>
+        /// <value>
+        /// The <see cref="Variable"/>.
+        /// </value>
+        /// <param name="index">The index.</param>
+        /// <returns>The variable at the specified index.</returns>
+        public Variable this[int index] => _unknowns[index];
+
+        /// <summary>
+        /// Gets the number of variables.
+        /// </summary>
+        public int Count => _unknowns.Count;
+
+        /// <summary>
+        /// Enumerate all variable names in the set.
+        /// </summary>
+        public IEnumerable<string> Keys => _map.Keys;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="VariableSet"/> class.
         /// </summary>
         public VariableSet()
@@ -56,21 +81,6 @@ namespace SpiceSharp.Simulations
             // Unlock
             _locked = false;
         }
-
-        /// <summary>
-        /// Gets the <see cref="Variable"/> at the specified index.
-        /// </summary>
-        /// <value>
-        /// The <see cref="Variable"/>.
-        /// </value>
-        /// <param name="index">The index.</param>
-        /// <returns>The variable at the specified index.</returns>
-        public Variable this[int index] => _unknowns[index];
-
-        /// <summary>
-        /// Gets the number of variables.
-        /// </summary>
-        public int Count => _unknowns.Count;
 
         /// <summary>
         /// This method maps a variable in the circuit. If a variable with the same identifier already exists, then that variable is returned.

--- a/SpiceSharp/SpiceSharp.csproj
+++ b/SpiceSharp/SpiceSharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.5;netstandard2.0;net45;netcoreapp2.0</TargetFrameworks>
-    <Version>2.7.2</Version>
+    <Version>2.7.3</Version>
     <Authors>Sven Boulanger</Authors>
     <Description>Spice# is a circuit simulator based on and improved from Spice 3f5 by Berkeley. The framework allows custom components and simulations to be added.</Description>
     <PackageProjectUrl>https://github.com/SpiceSharp/SpiceSharp</PackageProjectUrl>
@@ -10,12 +10,12 @@
     <RepositoryUrl>https://github.com/SpiceSharp/SpiceSharp</RepositoryUrl>
     <PackageTags>circuit electronics netlist parser spice simulator simulation ode solver design</PackageTags>
     <PackageIconUrl>https://raw.githubusercontent.com/SpiceSharp/SpiceSharp/master/api/images/logo_full.svg?sanitize=true</PackageIconUrl>
-    <AssemblyVersion>2.7.2.0</AssemblyVersion>
+    <AssemblyVersion>2.7.3.0</AssemblyVersion>
     <PackageReleaseNotes>Refer to the GitHub release for release notes</PackageReleaseNotes>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company />
     <NeutralLanguage>en-001</NeutralLanguage>
-    <FileVersion>2.7.2.0</FileVersion>
+    <FileVersion>2.7.3.0</FileVersion>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
- Exposing more properties to work with.
- Removed `Export<T>` export without simulation argument to avoid confusion. Just specify `null` there is no simulation yet to link with.