### PR TITLE
Made suggested changes

### DIFF
--- a/SpiceSharp/Simulations/Exports/RealPropertyExport.cs
+++ b/SpiceSharp/Simulations/Exports/RealPropertyExport.cs
@@ -19,6 +19,11 @@ namespace SpiceSharp.Simulations
         public string PropertyName { get; }
 
         /// <summary>
+        /// Gets the name of the entity in a subcircuit. Use an array of strings.
+        /// </summary>
+        public string[] SubcircuitEntityName { get; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="RealPropertyExport"/> class.
         /// </summary>
         /// <param name="simulation">The simulation.</param>
@@ -29,6 +34,23 @@ namespace SpiceSharp.Simulations
         {
             EntityName = entityName.ThrowIfNull(nameof(entityName));
             PropertyName = propertyName.ThrowIfNull(nameof(propertyName));
+            SubcircuitEntityName = null;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RealPropertyExport"/> class.
+        /// </summary>
+        /// <param name="simulation">The simulation.</param>
+        /// <param name="subcircuitEntityName">The subcircuit list of the entity.</param>
+        /// <param name="propertyName">The name of the property.</param>
+        public RealPropertyExport(IEventfulSimulation simulation, string[] subcircuitEntityName, string propertyName)
+            : base(simulation)
+        {
+            if (subcircuitEntityName == null || subcircuitEntityName.Length == 0)
+                throw new ArgumentException("subcircuitEntityName cannot be null or empty.", nameof(subcircuitEntityName));
+            EntityName = subcircuitEntityName[0];
+            PropertyName = propertyName.ThrowIfNull(nameof(propertyName));
+            SubcircuitEntityName = subcircuitEntityName.ThrowIfNull(nameof(subcircuitEntityName));
         }
 
         /// <summary>
@@ -39,9 +61,41 @@ namespace SpiceSharp.Simulations
         protected override void Initialize(object sender, EventArgs e)
         {
             e.ThrowIfNull(nameof(e));
-            var eb = Simulation.EntityBehaviors[EntityName];
-            if (eb != null)
-                Extractor = eb.CreatePropertyGetter<double>(PropertyName);
+            if (SubcircuitEntityName == null)//then using entity name
+            {
+                var eb = Simulation.EntityBehaviors[EntityName];
+                if (eb != null)
+                    Extractor = eb.CreatePropertyGetter<double>(PropertyName);
+            }
+            else//using subcircuit array of strings
+            {
+                string curComponentName = SubcircuitEntityName[0];
+                System.Collections.Generic.IEnumerator<Behaviors.IBehavior> entityEnum = Simulation.EntityBehaviors[curComponentName].GetEnumerator();
+                for (int i = 1; i < SubcircuitEntityName.Length; i++)
+                {
+                    string nextComponentName = SubcircuitEntityName[i];
+
+                    entityEnum.MoveNext();
+                    Components.Subcircuits.EntitiesBehavior behavior = (SpiceSharp.Components.Subcircuits.EntitiesBehavior)entityEnum.Current;
+                    Behaviors.IBehaviorContainerCollection localBehavior = behavior.LocalBehaviors;
+                    foreach (Behaviors.IBehaviorContainer bc in localBehavior)
+                    {
+                        if (bc.Name == nextComponentName)
+                        {
+                            if (i == SubcircuitEntityName.Length - 1)//if last name
+                            {
+                                Extractor = bc.CreatePropertyGetter<double>(PropertyName);
+                                return;
+                            }
+                            else//move to the next subcircuit
+                            {
+                                entityEnum = bc.GetEnumerator();
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/SpiceSharp/Simulations/Exports/RealPropertyExport.cs
+++ b/SpiceSharp/Simulations/Exports/RealPropertyExport.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace SpiceSharp.Simulations
 {
@@ -9,9 +10,9 @@ namespace SpiceSharp.Simulations
     public class RealPropertyExport : Export<IEventfulSimulation, double>
     {
         /// <summary>
-        /// Gets the name of the entity.
+        /// Gets the path to the name of the entity.
         /// </summary>
-        public string EntityName { get; }
+        public IReadOnlyList<string> EntityPath { get; }
 
         /// <summary>
         /// Gets the name of the property.
@@ -19,38 +20,32 @@ namespace SpiceSharp.Simulations
         public string PropertyName { get; }
 
         /// <summary>
-        /// Gets the name of the entity in a subcircuit. Use an array of strings.
-        /// </summary>
-        public string[] SubcircuitEntityName { get; }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="RealPropertyExport"/> class.
         /// </summary>
         /// <param name="simulation">The simulation.</param>
-        /// <param name="entityName">The name of the entity.</param>
+        /// <param name="entityPath">The path to the name of the entity.</param>
         /// <param name="propertyName">The name of the property.</param>
-        public RealPropertyExport(IEventfulSimulation simulation, string entityName, string propertyName)
+        public RealPropertyExport(IEventfulSimulation simulation, string entityPath, string propertyName)
             : base(simulation)
         {
-            EntityName = entityName.ThrowIfNull(nameof(entityName));
+            entityPath.ThrowIfNull(nameof(entityPath));
+            EntityPath = new List<string> { entityPath };
             PropertyName = propertyName.ThrowIfNull(nameof(propertyName));
-            SubcircuitEntityName = null;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RealPropertyExport"/> class.
         /// </summary>
         /// <param name="simulation">The simulation.</param>
-        /// <param name="subcircuitEntityName">The subcircuit list of the entity.</param>
+        /// <param name="entityPath">The subcircuit list of the entity.</param>
         /// <param name="propertyName">The name of the property.</param>
-        public RealPropertyExport(IEventfulSimulation simulation, string[] subcircuitEntityName, string propertyName)
+        public RealPropertyExport(IEventfulSimulation simulation, string[] entityPath, string propertyName)
             : base(simulation)
         {
-            if (subcircuitEntityName == null || subcircuitEntityName.Length == 0)
-                throw new ArgumentException("subcircuitEntityName cannot be null or empty.", nameof(subcircuitEntityName));
-            EntityName = subcircuitEntityName[0];
+            if (entityPath == null || entityPath.Length == 0)
+                throw new ArgumentNullException("entityPath cannot be null or empty.", nameof(entityPath));
+            EntityPath = new List<string>(entityPath);
             PropertyName = propertyName.ThrowIfNull(nameof(propertyName));
-            SubcircuitEntityName = subcircuitEntityName.ThrowIfNull(nameof(subcircuitEntityName));
         }
 
         /// <summary>
@@ -61,19 +56,19 @@ namespace SpiceSharp.Simulations
         protected override void Initialize(object sender, EventArgs e)
         {
             e.ThrowIfNull(nameof(e));
-            if (SubcircuitEntityName == null)//then using entity name
+            if (EntityPath.Count == 1)//then path is entity name
             {
-                var eb = Simulation.EntityBehaviors[EntityName];
+                var eb = Simulation.EntityBehaviors[EntityPath[0]];
                 if (eb != null)
                     Extractor = eb.CreatePropertyGetter<double>(PropertyName);
             }
             else//using subcircuit array of strings
             {
-                string curComponentName = SubcircuitEntityName[0];
+                string curComponentName = EntityPath[0];
                 System.Collections.Generic.IEnumerator<Behaviors.IBehavior> entityEnum = Simulation.EntityBehaviors[curComponentName].GetEnumerator();
-                for (int i = 1; i < SubcircuitEntityName.Length; i++)
+                for (int i = 1; i < EntityPath.Count; i++)
                 {
-                    string nextComponentName = SubcircuitEntityName[i];
+                    string nextComponentName = EntityPath[i];
 
                     entityEnum.MoveNext();
                     Components.Subcircuits.EntitiesBehavior behavior = (SpiceSharp.Components.Subcircuits.EntitiesBehavior)entityEnum.Current;
@@ -82,7 +77,7 @@ namespace SpiceSharp.Simulations
                     {
                         if (bc.Name == nextComponentName)
                         {
-                            if (i == SubcircuitEntityName.Length - 1)//if last name
+                            if (i == EntityPath.Count - 1)//if last name
                             {
                                 Extractor = bc.CreatePropertyGetter<double>(PropertyName);
                                 return;

--- a/SpiceSharpTest/Models/Subcircuits/SimpleSubcircuitTests.cs
+++ b/SpiceSharpTest/Models/Subcircuits/SimpleSubcircuitTests.cs
@@ -102,9 +102,102 @@ namespace SpiceSharpTest.Models
             var op = new OP("op");
             string[] subcircuitCurrent1 = { "X1", "Vdiv", "R1" };
             string[] subcircuitCurrent2 = { "X1", "R1" };
-            IExport<double>[] exports = new[] { new RealPropertyExport(op, subcircuitCurrent1, "i"), new RealPropertyExport(op, subcircuitCurrent2, "i") };
-            IEnumerable<double> references = new double[] { 5 / 2e3, 5 };
+            string[] subcircuitVoltage1 = { "X1", "Vdiv", "R2" };//get voltage across R2
+            IExport<double>[] exports = new[] { new RealPropertyExport(op, subcircuitCurrent1, "i"), new RealPropertyExport(op, subcircuitCurrent2, "i"), new RealPropertyExport(op, subcircuitVoltage1, "v") };
+            IEnumerable<double> references = new double[] { 5 / 2e3, 5, 2.5 };
             AnalyzeOp(op, ckt, exports, references);
+        }
+
+        [Test]
+        public void When_SimpleSubcircuit_DC_Measure_Multi_Subcircuit()
+        {
+            // Define the subcircuit
+            var subckt1 = new SubcircuitDefinition(new Circuit(
+                new Resistor("R1", "a", "b", 1e3),
+                new Resistor("R2", "b", "0", 1e3)),
+                "a");
+
+            // board level
+            var subckt2 = new SubcircuitDefinition(new Circuit(
+                new Resistor("R1", "in", "0", 1),//same name to make sure it finds correct R1
+                new Subcircuit("Vdiv", subckt1).Connect("in")),
+                "in");
+
+            //connect voltage source to board
+            var ckt = new Circuit(
+                new VoltageSource("V1", "in", "0", 5.0),
+                new Subcircuit("X1", subckt2).Connect("in"));
+
+            // <example01_simulate2>
+            // Create a DC simulation that sweeps V1 from 1V to 2V in steps of 1V
+            var dc = new DC("DC 1", "V1", 1.0,2.0,1.0);
+
+            // Create exports
+            string[] subcircuitOutput = { "X1", "Vdiv", "R2" };
+
+            // Create exports
+            IExport<double>[] exports = { new RealPropertyExport(dc, "V1", "v"), new RealPropertyExport(dc, subcircuitOutput, "v"), new RealPropertyExport(dc, subcircuitOutput, "i"),
+                                            new RealPropertyExport(dc, subcircuitOutput, "resistance")};
+
+            double[][] references =
+            {
+                new[] { 1.0, 2.0 },
+                new[] { 0.5, 1.0 },
+                new[] { 1/2e3, 2/2e3},
+                new[] { 1e3, 1e3},
+            };
+
+            // Run test
+            AnalyzeDC(dc, ckt, exports, references);
+            DestroyExports(exports);
+        }
+        [Test]
+        public void When_SimpleSubcircuit_Tran_Measure_Multi_Subcircuit()
+        {
+            // Define the subcircuit
+            var subckt1 = new SubcircuitDefinition(new Circuit(
+                new Resistor("R1", "a", "b", 1e3),
+                new Resistor("R2", "b", "0", 1e3)),
+                "a");
+
+            // board level
+            var subckt2 = new SubcircuitDefinition(new Circuit(
+                new Resistor("R1", "in", "0", 1),//same name to make sure it finds correct R1
+                new Subcircuit("Vdiv", subckt1).Connect("in")),
+                "in");
+
+            //connect voltage source to board
+            var ckt = new Circuit(
+                new VoltageSource("V1", "in", "0", 5.0),
+                new Subcircuit("X1", subckt2).Connect("in"));
+
+            // <example01_simulate2>
+            var tran = new Transient("transient", 1e-9, 2e-11);
+
+            // Create exports
+            string[] subcircuitOutput = { "X1", "Vdiv", "R2" };
+
+            // Create exports
+            IExport<double>[] exports = { new GenericExport<double>(tran, () => tran.GetState<IIntegrationMethod>().Time),
+                                        new RealPropertyExport(tran, "V1", "v"),
+                                        new RealPropertyExport(tran, subcircuitOutput, "v"),
+                                        new RealPropertyExport(tran, subcircuitOutput, "i"),
+                                        new RealPropertyExport(tran, subcircuitOutput, "resistance")
+                                        };
+
+            // Create references
+            IEnumerable<Func<double, double>> references = new Func<double, double>[] {
+                t => t,
+                t => 5.0,
+                t => 2.5,
+                t => 5/2e3,
+                t => 1e3,
+            };
+
+            // Run test
+            AnalyzeTransient(tran, ckt, exports, references);
+            DestroyExports(exports);
+
         }
 
         [Test]


### PR DESCRIPTION
Added more tests cases. all pass. (op, dc, tran)
checking more parameters. (i,v,resistance)
changed EntityName to EntityPath and made it IReadOnlyList<string>
2 constructors. 1 takes in a string, that gets converted to IReadOnlyList<string>. this maintains legacy code
new constructor is an array of strings, that then get converted to a List<string>. let me know if you prefer the constructor to take the List<string> instead of string[].
