### PR TITLE
Clean up the csproj files

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,50 @@
-<Project>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  
+  <!-- Directories -->
   <PropertyGroup>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <RepoRoot>$(MSBuildThisFileDirectory)</RepoRoot>
+    <UserDocsDir>$(RepoRoot)docs/</UserDocsDir>
+    <BuildDir>$(RepoRoot)build\</BuildDir>
+    <DocPath>$(BuildDir)doc\</DocPath>
   </PropertyGroup>
+  
+  <!-- Build info -->
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <NeutralLanguage>en</NeutralLanguage>
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+    <LangVersion>latest</LangVersion>
+	<OutputPath>$(BuildDir)bin\$(MSBuildProjectName)\</OutputPath>
+    <BaseIntermediateOutputPath>$(BuildDir)obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
+    <DocumentationFile>$(DocPath)$(MSBuildProjectName).xml</DocumentationFile>
+  </PropertyGroup>
+  
+  <!-- Assembly info -->
+  <PropertyGroup>
+    <Version>3.1.9</Version>
+	<AssemblyVersion>3.1.9.0</AssemblyVersion>
+    <Authors>Sven Boulanger</Authors>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Title>Spice#</Title>
+    <Company>SpiceSharp</Company>
+  </PropertyGroup>
+  
+  <!-- NuGet package info -->
+  <PropertyGroup>
+    <PackageProjectUrl>https://github.com/SpiceSharp/SpiceSharp</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/SpiceSharp/SpiceSharp</RepositoryUrl>
+    <PackageTags>circuit electronics netlist spice simulator simulation ode solver design</PackageTags>
+	<PackageReleaseNotes>Refer to the GitHub release for release notes.</PackageReleaseNotes>
+    <PackageIcon>logo_full.png</PackageIcon> 
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>circuit electronics netlist parser spice simulator simulation ode solver design</PackageTags>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="$(UserDocsDir)api/images/logo_full.png" Pack="true" Visible="false" PackagePath="" />
+    <None Include="$(RepoRoot)README.md" Pack="true" Visible="false" PackagePath="" />
+  </ItemGroup>
+  
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -16,6 +16,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   
   <!-- Disable some rules for test projects -->

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,26 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  
+  <!-- Only create packages for non-test projects -->
+  <PropertyGroup Condition="'$(TestProjectType)' == ''">
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+  </PropertyGroup>
+  
+  <!-- Include the default test packages for test projects -->
+  <ItemGroup Condition="'$(TestProjectType)' != ''">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
+    <PackageReference Include="NUnit.Console" Version="3.17.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  
+  <!-- Disable some rules for test projects -->
+  <PropertyGroup Condition="'$(TestProjectType)' != ''">
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+  
+</Project>

--- a/SpiceSharp/SpiceSharp.csproj
+++ b/SpiceSharp/SpiceSharp.csproj
@@ -1,48 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0</TargetFrameworks>
-		<Version>3.1.9</Version>
-		<Authors>Sven Boulanger</Authors>
-		<Title>Spice#</Title>
-		<Description>Spice# is a circuit simulator based on and improved from Spice 3f5 by Berkeley. The framework allows custom components and simulations to be added.</Description>
-		<PackageProjectUrl>https://github.com/SpiceSharp/SpiceSharp</PackageProjectUrl>
-		<PackageLicenseUrl></PackageLicenseUrl>
-		<RepositoryUrl>https://github.com/SpiceSharp/SpiceSharp</RepositoryUrl>
-		<PackageTags>circuit electronics netlist spice simulator simulation ode solver design</PackageTags>
-		<AssemblyVersion>3.1.9.0</AssemblyVersion>
-		<PackageReleaseNotes>Refer to the GitHub release for release notes.</PackageReleaseNotes>
-		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<Company />
-		<NeutralLanguage>en</NeutralLanguage>
-		<FileVersion>3.1.8.0</FileVersion>
-		<DebugType>full</DebugType>
-		<DebugSymbols>true</DebugSymbols>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<Copyright />
-		<LangVersion>latest</LangVersion>
-		<PackageIcon>logo_full.png</PackageIcon>
-		<RepositoryType>git</RepositoryType>
-		<PackageReadmeFile>README.md</PackageReadmeFile>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard1.5|AnyCPU'">
-		<DocumentationFile></DocumentationFile>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard1.5|AnyCPU'">
-		<DocumentationFile></DocumentationFile>
-	</PropertyGroup>
-
-	<ItemGroup>
-		<Compile Remove="Simulations\Implementations\PoleZeros\**" />
-		<EmbeddedResource Remove="Simulations\Implementations\PoleZeros\**" />
-		<None Remove="Simulations\Implementations\PoleZeros\**" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Compile Remove="Algebra\Polynomials\RationalPolynomial.cs" />
-	</ItemGroup>
+  <PropertyGroup>
+    <Description>Spice# is a circuit simulator based on and improved from Spice 3f5 by Berkeley. The framework allows custom components and simulations to be added.</Description>
+  </PropertyGroup>
 
 	<ItemGroup>
 		<Compile Update="Properties\Resources.Designer.cs">
@@ -64,16 +24,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<None Include="..\docs\api\images\logo_full.png">
-			<Pack>True</Pack>
-			<PackagePath></PackagePath>
-		</None>
-		<None Include="..\README.md">
-		  <Pack>True</Pack>
-		  <PackagePath>\</PackagePath>
-		</None>
+		<ProjectReference Include="$(RepoRoot)SpiceSharpGenerator/SpiceSharpGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
 	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="../SpiceSharpGenerator/SpiceSharpGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-	</ItemGroup>
+
 </Project>

--- a/SpiceSharp/SpiceSharp.csproj
+++ b/SpiceSharp/SpiceSharp.csproj
@@ -10,17 +10,10 @@
 			<AutoGen>True</AutoGen>
 			<DependentUpon>Resources.resx</DependentUpon>
 		</Compile>
-	</ItemGroup>
-
-	<ItemGroup>
 		<EmbeddedResource Update="Properties\Resources.resx">
 			<Generator>PublicResXFileCodeGenerator</Generator>
 			<LastGenOutput>Resources.Designer.cs</LastGenOutput>
 		</EmbeddedResource>
-	</ItemGroup>
-
-	<ItemGroup>
-		<Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/SpiceSharpGenerator/BehaviorGenerator.cs
+++ b/SpiceSharpGenerator/BehaviorGenerator.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.CodeAnalysis;
-using SpiceSharpGenerator.Diagnostics;
 using System.Collections.Generic;
 using System.Linq;
 using ClassDeclarationSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.ClassDeclarationSyntax;

--- a/SpiceSharpGenerator/SpiceSharpGenerator.csproj
+++ b/SpiceSharpGenerator/SpiceSharpGenerator.csproj
@@ -1,44 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
-		<LangVersion>latest</LangVersion>
 		<IncludeBuildOutput>false</IncludeBuildOutput>
 		<DevelopmentDependency>true</DevelopmentDependency>
-		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
-		<Authors>Sven Boulanger</Authors>
-		<Company>SpiceSharp</Company>
-		<Product>SpiceSharp.Generator</Product>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
 		<Description>A source generator that is built to help extending the functionality of the SpiceSharp framework.</Description>
-		<PackageIcon>logo_full.png</PackageIcon>
-		<Copyright></Copyright>
-		<RepositoryUrl>https://github.com/SpiceSharp/SpiceSharp</RepositoryUrl>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<RepositoryType>git</RepositoryType>
-		<PackageTags>circuit electronics netlist parser spice simulator simulation ode solver design</PackageTags>
-		<PackageReleaseNotes>Refer to the GitHub release for release notes.</PackageReleaseNotes>
 		<Version>1.0.5</Version>
 		<AssemblyVersion>1.0.5.0</AssemblyVersion>
+    <NoWarn>$(NoWarn);RS1035</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<None Remove="bin\Debug\netstandard2.0\SpiceSharpGenerator.dll" />
+		<None Include="$(OutputPath)$(AssemblyName).dll" Pack="true" Visible="false" PackagePath="analyzers\dotnet\cs" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<None Include="$(OutputPath)\$(AssemblyName).dll" Visible="false">
-			<Pack>True</Pack>
-			<PackagePath>analyzers\dotnet\cs</PackagePath>
-		</None>
-		<None Include="..\docs\api\images\logo_full.png">
-			<Pack>True</Pack>
-			<PackagePath></PackagePath>
-		</None>
-	</ItemGroup>
-
-	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
 	</ItemGroup>
 </Project>

--- a/SpiceSharpGenerator/SyntaxReceiver.cs
+++ b/SpiceSharpGenerator/SyntaxReceiver.cs
@@ -32,7 +32,7 @@ namespace SpiceSharpGenerator
                 return StringComparer.Ordinal.GetHashCode(obj);
             }
         }
-        private Dictionary<string, Action<AttributeSyntax>> _categories = new(new AttributeComparer());
+        private readonly Dictionary<string, Action<AttributeSyntax>> _categories = new(new AttributeComparer());
 
         /// <summary>
         /// Gets the list of eligible entities that may need to be extended using code generation.

--- a/SpiceSharpTest/Algebra/DenseFactorTests.cs
+++ b/SpiceSharpTest/Algebra/DenseFactorTests.cs
@@ -1,6 +1,5 @@
 ﻿using NUnit.Framework;
 using SpiceSharp.Algebra;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Algebra
 {
@@ -34,7 +33,7 @@ namespace SpiceSharpTest.Algebra
             // Compare
             for (int r = 0; r < matrixElements.Length; r++)
                 for (int c = 0; c < matrixElements[r].Length; c++)
-                    Assert.AreEqual(expected[r][c], solver[r + 1, c + 1], 1e-12);
+                    Assert.That(solver[r + 1, c + 1], Is.EqualTo(expected[r][c]).Within(1e-12));
         }
 
         [Test]
@@ -50,18 +49,18 @@ namespace SpiceSharpTest.Algebra
             solver[5, 4] = 1;
 
             // Order and factor
-            Assert.AreEqual(solver.Size, solver.OrderAndFactor());
+            Assert.That(solver.OrderAndFactor(), Is.EqualTo(solver.Size));
 
             // Compare
-            Assert.AreEqual(solver[1, 1], 1.0);
-            Assert.AreEqual(solver[1, 4], -1.0);
-            Assert.AreEqual(solver[2, 1], -1.0);
-            Assert.AreEqual(solver[2, 3], 1.0);
-            Assert.AreEqual(solver[2, 4], -1.0);
-            Assert.AreEqual(solver[3, 2], 1.0);
-            Assert.AreEqual(solver[3, 2], 1.0);
-            Assert.AreEqual(solver[4, 5], 1.0);
-            Assert.AreEqual(solver[5, 4], 1.0);
+            Assert.That(solver[1, 1], Is.EqualTo(1.0));
+            Assert.That(solver[1, 4], Is.EqualTo(-1.0));
+            Assert.That(solver[2, 1], Is.EqualTo(-1.0));
+            Assert.That(solver[2, 3], Is.EqualTo(1.0));
+            Assert.That(solver[2, 4], Is.EqualTo(-1.0));
+            Assert.That(solver[3, 2], Is.EqualTo(1.0));
+            Assert.That(solver[3, 2], Is.EqualTo(1.0));
+            Assert.That(solver[4, 5], Is.EqualTo(1.0));
+            Assert.That(solver[5, 4], Is.EqualTo(1.0));
         }
     }
 }

--- a/SpiceSharpTest/Algebra/DenseFactorTests.cs
+++ b/SpiceSharpTest/Algebra/DenseFactorTests.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using SpiceSharp.Algebra;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Algebra
 {

--- a/SpiceSharpTest/Algebra/DenseMatrixTests.cs
+++ b/SpiceSharpTest/Algebra/DenseMatrixTests.cs
@@ -1,6 +1,5 @@
 ﻿using NUnit.Framework;
 using SpiceSharp.Algebra;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Algebra
 {
@@ -13,13 +12,13 @@ namespace SpiceSharpTest.Algebra
             var n = new DenseMatrix<double>();
             n[10, 10] = 3;
 
-            Assert.AreEqual(10, n.Size);
-            Assert.AreEqual(3.0, n[10, 10], 1e-12);
+            Assert.That(n.Size, Is.EqualTo(10));
+            Assert.That(n[10, 10], Is.EqualTo(3.0).Within(1e-12));
 
             n.Clear();
 
-            Assert.AreEqual(0, n.Size);
-            Assert.AreEqual(0.0, n[10, 10], 1e-12);
+            Assert.That(n.Size, Is.EqualTo(0));
+            Assert.That(n[10, 10], Is.EqualTo(0.0).Within(1e-12));
         }
 
         [Test]
@@ -36,7 +35,7 @@ namespace SpiceSharpTest.Algebra
             {
                 int row = r == 2 ? 5 : r == 5 ? 2 : r;
                 for (int c = 1; c < 10; c++)
-                    Assert.AreEqual((row - 1) * 10 + c, n[r, c], 1e-12);
+                    Assert.That(n[r, c], Is.EqualTo((row - 1) * 10 + c).Within(1e-12));
             }
 
             n.Clear();
@@ -57,7 +56,7 @@ namespace SpiceSharpTest.Algebra
                 for (int c = 1; c < 10; c++)
                 {
                     int col = c == 2 ? 5 : c == 5 ? 2 : c;
-                    Assert.AreEqual((r - 1) * 10 + col, n[r, c], 1e-12);
+                    Assert.That(n[r, c], Is.EqualTo((r - 1) * 10 + col).Within(1e-12));
                 }
             }
 

--- a/SpiceSharpTest/Algebra/DenseMatrixTests.cs
+++ b/SpiceSharpTest/Algebra/DenseMatrixTests.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using SpiceSharp.Algebra;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Algebra
 {

--- a/SpiceSharpTest/Algebra/DenseSolverTests.cs
+++ b/SpiceSharpTest/Algebra/DenseSolverTests.cs
@@ -1,7 +1,6 @@
 ﻿using NUnit.Framework;
 using SpiceSharp.Algebra;
 using System;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Algebra
 {
@@ -29,14 +28,14 @@ namespace SpiceSharpTest.Algebra
             solver[4] = 8;
 
             var solution = new DenseVector<double>(4);
-            Assert.AreEqual(4, solver.OrderAndFactor());
+            Assert.That(solver.OrderAndFactor(), Is.EqualTo(4));
             solver.ForwardSubstitute(solution);
             solver.BackwardSubstitute(solution);
 
-            Assert.AreEqual(solution[1], -9.0 / 4.0, 1e-12);
-            Assert.AreEqual(solution[2], 2.0, 1e-12);
-            Assert.AreEqual(solution[3], 5.0 / 4.0, 1e-12);
-            Assert.AreEqual(solution[4], 1.0, 1e-12);
+            Assert.That(solution[1], Is.EqualTo(-9.0 / 4.0).Within(1e-12));
+            Assert.That(solution[2], Is.EqualTo(2.0).Within(1e-12));
+            Assert.That(solution[3], Is.EqualTo(5.0 / 4.0).Within(1e-12));
+            Assert.That(solution[4], Is.EqualTo(1.0).Within(1e-12));
         }
 
         [Test]
@@ -64,7 +63,7 @@ namespace SpiceSharpTest.Algebra
             for (int i = 0; i < sol.Length; i++)
             {
                 double tol = Math.Max(Math.Abs(sol[i + 1]), Math.Abs(reference[i])) * 1e-12;
-                Assert.AreEqual(reference[i], sol[i + 1], tol);
+                Assert.That(sol[i + 1], Is.EqualTo(reference[i]).Within(tol));
             }
         }
     }

--- a/SpiceSharpTest/Algebra/DenseSolverTests.cs
+++ b/SpiceSharpTest/Algebra/DenseSolverTests.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using SpiceSharp.Algebra;
 using System;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Algebra
 {

--- a/SpiceSharpTest/Algebra/DenseVectorTests.cs
+++ b/SpiceSharpTest/Algebra/DenseVectorTests.cs
@@ -1,6 +1,5 @@
 ﻿using NUnit.Framework;
 using SpiceSharp.Algebra;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Algebra
 {
@@ -17,7 +16,7 @@ namespace SpiceSharpTest.Algebra
             vector.SwapElements(2, 4);
 
             for (int k = 1; k <= 5; k++)
-                Assert.AreEqual(k == 2 ? 4 : k == 4 ? 2 : k, vector[k], 1e-12);
+                Assert.That(vector[k], Is.EqualTo(k == 2 ? 4 : k == 4 ? 2 : k).Within(1e-12));
         }
     }
 }

--- a/SpiceSharpTest/Algebra/DenseVectorTests.cs
+++ b/SpiceSharpTest/Algebra/DenseVectorTests.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using SpiceSharp.Algebra;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Algebra
 {

--- a/SpiceSharpTest/Algebra/SparseFactorTests.cs
+++ b/SpiceSharpTest/Algebra/SparseFactorTests.cs
@@ -3,7 +3,6 @@
 using NUnit.Framework;
 using SpiceSharp.Algebra;
 using System;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Algebra
 {
@@ -38,7 +37,7 @@ namespace SpiceSharpTest.Algebra
             // Compare
             for (int r = 0; r < matrixElements.Length; r++)
                 for (int c = 0; c < matrixElements[r].Length; c++)
-                    Assert.AreEqual(expected[r][c], solver.GetElement(new MatrixLocation(r + 1, c + 1)).Value, 1e-12);
+                    Assert.That(solver.GetElement(new MatrixLocation(r + 1, c + 1)).Value, Is.EqualTo(expected[r][c]).Within(1e-12));
         }
 
         [Test]
@@ -58,20 +57,20 @@ namespace SpiceSharpTest.Algebra
             solver.GetElement(new MatrixLocation(5, 5)).Value = 1.0;
 
             // Order and factor
-            Assert.AreEqual(5, solver.OrderAndFactor());
+            Assert.That(solver.OrderAndFactor(), Is.EqualTo(5));
 
             // Compare
-            Assert.AreEqual(solver.GetElement(new MatrixLocation(1, 1)).Value, 1.0e4);
-            Assert.AreEqual(solver.GetElement(new MatrixLocation(1, 4)).Value, -0.0001);
-            Assert.AreEqual(solver.GetElement(new MatrixLocation(1, 5)).Value, 0.0);
-            Assert.AreEqual(solver.GetElement(new MatrixLocation(2, 1)).Value, 0.0);
-            Assert.AreEqual(solver.GetElement(new MatrixLocation(2, 2)).Value, 1.0);
-            Assert.AreEqual(solver.GetElement(new MatrixLocation(2, 5)).Value, 0.0);
-            Assert.AreEqual(solver.GetElement(new MatrixLocation(3, 1)).Value, -0.0001);
-            Assert.AreEqual(solver.GetElement(new MatrixLocation(3, 3)).Value, 1.0);
-            Assert.AreEqual(solver.GetElement(new MatrixLocation(3, 4)).Value, 0.0001);
-            Assert.AreEqual(solver.GetElement(new MatrixLocation(4, 4)).Value, 1.0);
-            Assert.AreEqual(solver.GetElement(new MatrixLocation(5, 5)).Value, 1.0);
+            Assert.That(solver.GetElement(new MatrixLocation(1, 1)).Value, Is.EqualTo(1.0e4));
+            Assert.That(solver.GetElement(new MatrixLocation(1, 4)).Value, Is.EqualTo(-0.0001));
+            Assert.That(solver.GetElement(new MatrixLocation(1, 5)).Value, Is.EqualTo(0.0));
+            Assert.That(solver.GetElement(new MatrixLocation(2, 1)).Value, Is.EqualTo(0.0));
+            Assert.That(solver.GetElement(new MatrixLocation(2, 2)).Value, Is.EqualTo(1.0));
+            Assert.That(solver.GetElement(new MatrixLocation(2, 5)).Value, Is.EqualTo(0.0));
+            Assert.That(solver.GetElement(new MatrixLocation(3, 1)).Value, Is.EqualTo(-0.0001));
+            Assert.That(solver.GetElement(new MatrixLocation(3, 3)).Value, Is.EqualTo(1.0));
+            Assert.That(solver.GetElement(new MatrixLocation(3, 4)).Value, Is.EqualTo(0.0001));
+            Assert.That(solver.GetElement(new MatrixLocation(4, 4)).Value, Is.EqualTo(1.0));
+            Assert.That(solver.GetElement(new MatrixLocation(5, 5)).Value, Is.EqualTo(1.0));
         }
 
         [Test]
@@ -90,7 +89,7 @@ namespace SpiceSharpTest.Algebra
             solver.GetElement(new MatrixLocation(5, 4)).Value = -1e-4;
             solver.GetElement(new MatrixLocation(5, 5)).Value = 1e-4;
 
-            Assert.AreEqual(5, solver.OrderAndFactor());
+            Assert.That(solver.OrderAndFactor(), Is.EqualTo(5));
 
             AssertInternal(solver, 1, 1, 1.0);
             AssertInternal(solver, 2, 1, 0.0);
@@ -149,7 +148,7 @@ namespace SpiceSharpTest.Algebra
             solver[3, 3] = 1;
 
             solver.Degeneracy = 1;
-            Assert.AreEqual(true, solver.Factor());
+            Assert.That(solver.Factor(), Is.EqualTo(true));
 
             AssertInternal(solver, 1, 1, 1);
             AssertInternal(solver, 2, 2, 1);
@@ -171,8 +170,8 @@ namespace SpiceSharpTest.Algebra
             var indices = new MatrixLocation(row, col);
             indices = solver.InternalToExternal(indices);
             var elt = solver.FindElement(indices);
-            Assert.AreNotEqual(null, elt);
-            Assert.AreEqual(expected, elt.Value);
+            Assert.That(elt, Is.Not.Null);
+            Assert.That(elt.Value, Is.EqualTo(expected));
         }
     }
 }

--- a/SpiceSharpTest/Algebra/SparseFactorTests.cs
+++ b/SpiceSharpTest/Algebra/SparseFactorTests.cs
@@ -3,6 +3,7 @@
 using NUnit.Framework;
 using SpiceSharp.Algebra;
 using System;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Algebra
 {

--- a/SpiceSharpTest/Algebra/SparseMatrixTests.cs
+++ b/SpiceSharpTest/Algebra/SparseMatrixTests.cs
@@ -2,6 +2,7 @@
 using SpiceSharp.Algebra;
 using System.Collections;
 using System.Collections.Generic;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Algebra
 {

--- a/SpiceSharpTest/Algebra/SparseMatrixTests.cs
+++ b/SpiceSharpTest/Algebra/SparseMatrixTests.cs
@@ -1,8 +1,6 @@
 ﻿using NUnit.Framework;
 using SpiceSharp.Algebra;
-using System.Collections;
 using System.Collections.Generic;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Algebra
 {
@@ -36,7 +34,7 @@ namespace SpiceSharpTest.Algebra
                 for (int c = 0; c < size; c++)
                 {
                     int expected = r * size + c + 1;
-                    Assert.AreEqual(expected, element.Value, 1e-12);
+                    Assert.That(element.Value, Is.EqualTo(expected).Within(1e-12));
                     element = element.Right;
                 }
             }
@@ -48,7 +46,7 @@ namespace SpiceSharpTest.Algebra
                 for (int c = size - 1; c >= 0; c--)
                 {
                     int expected = r * size + c + 1;
-                    Assert.AreEqual(expected, element.Value, 1e-12);
+                    Assert.That(element.Value, Is.EqualTo(expected).Within(1e-12));
                     element = element.Left;
                 }
             }
@@ -60,7 +58,7 @@ namespace SpiceSharpTest.Algebra
                 for (int r = 0; r < size; r++)
                 {
                     int expected = r * size + c + 1;
-                    Assert.AreEqual(expected, element.Value, 1e-12);
+                    Assert.That(element.Value, Is.EqualTo(expected).Within(1e-12));
                     element = element.Below;
                 }
             }
@@ -72,7 +70,7 @@ namespace SpiceSharpTest.Algebra
                 for (int r = size - 1; r >= 0; r--)
                 {
                     int expected = r * size + c + 1;
-                    Assert.AreEqual(expected, element.Value, 1e-12);
+                    Assert.That(element.Value, Is.EqualTo(expected).Within(1e-12));
                     element = element.Above;
                 }
             }
@@ -122,10 +120,10 @@ namespace SpiceSharpTest.Algebra
                     if ((fill & 0x01) != 0)
                     {
                         int expected = k * 32 + i + 1;
-                        Assert.AreEqual(expected, matrix[crow, i + 1], 1e-12);
+                        Assert.That(matrix[crow, i + 1], Is.EqualTo(expected).Within(1e-12));
                     }
                     else
-                        Assert.AreEqual(null, matrix.FindElement(new MatrixLocation(crow, i + 1)));
+                        Assert.That(matrix.FindElement(new MatrixLocation(crow, i + 1)), Is.EqualTo(null));
                     fill = (fill >> 1) & 0b011111;
                 }
             }
@@ -175,10 +173,10 @@ namespace SpiceSharpTest.Algebra
                     if ((fill & 0x01) != 0)
                     {
                         int expected = k * 32 + i + 1;
-                        Assert.AreEqual(expected, matrix[i + 1, ccolumn], 1e-12);
+                        Assert.That(matrix[i + 1, ccolumn], Is.EqualTo(expected).Within(1e-12));
                     }
                     else
-                        Assert.AreEqual(null, matrix.FindElement(new MatrixLocation(i + 1, ccolumn)));
+                        Assert.That(matrix.FindElement(new MatrixLocation(i + 1, ccolumn)), Is.EqualTo(null));
                     fill = (fill >> 1) & 0b011111;
                 }
             }
@@ -209,9 +207,9 @@ namespace SpiceSharpTest.Algebra
                 for (int c = 1; c <= 3; c++)
                 {
                     if (r == row && c == column)
-                        Assert.AreEqual(null, matrix.FindElement(new MatrixLocation(r, c)));
+                        Assert.That(matrix.FindElement(new MatrixLocation(r, c)), Is.EqualTo(null));
                     else
-                        Assert.AreEqual(index, matrix.FindElement(new MatrixLocation(r, c)).Value, 1e-9);
+                        Assert.That(matrix.FindElement(new MatrixLocation(r, c)).Value, Is.EqualTo(index).Within(1e-9));
                     index++;
                 }
             }

--- a/SpiceSharpTest/Algebra/SparseSolverTests.cs
+++ b/SpiceSharpTest/Algebra/SparseSolverTests.cs
@@ -5,6 +5,7 @@ using SpiceSharp.Simulations;
 using System;
 using System.IO;
 using System.Numerics;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Algebra
 {

--- a/SpiceSharpTest/Algebra/SparseSolverTests.cs
+++ b/SpiceSharpTest/Algebra/SparseSolverTests.cs
@@ -5,7 +5,6 @@ using SpiceSharp.Simulations;
 using System;
 using System.IO;
 using System.Numerics;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Algebra
 {
@@ -20,7 +19,7 @@ namespace SpiceSharpTest.Algebra
             ReadMatrix(solver, Path.Combine(TestContext.CurrentContext.TestDirectory, Path.Combine("Algebra", "Matrices", "fidapm05")));
 
             // Order and factor this larger matrix
-            Assert.AreEqual(solver.Size, solver.OrderAndFactor());
+            Assert.That(solver.OrderAndFactor(), Is.EqualTo(solver.Size));
         }
 
         [Test]
@@ -34,7 +33,7 @@ namespace SpiceSharpTest.Algebra
             // Order and factor
             ModifiedNodalAnalysisHelper<double>.Magnitude = Math.Abs;
             solver.Precondition((matrix, vector) => ModifiedNodalAnalysisHelper<double>.PreorderModifiedNodalAnalysis(matrix, matrix.Size));
-            Assert.AreEqual(solver.Size, solver.OrderAndFactor());
+            Assert.That(solver.OrderAndFactor(), Is.EqualTo(solver.Size));
 
             IVector<double> solution = new DenseVector<double>(solver.Size);
             solver.ForwardSubstitute(solution);
@@ -70,7 +69,7 @@ namespace SpiceSharpTest.Algebra
             }
 
             // This should run without throwing an exception
-            Assert.AreEqual(solver.Size, solver.OrderAndFactor());
+            Assert.That(solver.OrderAndFactor(), Is.EqualTo(solver.Size));
         }
 
         [Test]
@@ -103,7 +102,7 @@ namespace SpiceSharpTest.Algebra
             }
 
             // This should run without throwing an exception
-            Assert.AreEqual(solver.Size, solver.OrderAndFactor());
+            Assert.That(solver.OrderAndFactor(), Is.EqualTo(solver.Size));
         }
 
         [Test]
@@ -136,7 +135,7 @@ namespace SpiceSharpTest.Algebra
             }
 
             // This should run without throwing an exception
-            Assert.AreEqual(solver.Size, solver.OrderAndFactor());
+            Assert.That(solver.OrderAndFactor(), Is.EqualTo(solver.Size));
         }
 
         [Test]
@@ -169,7 +168,7 @@ namespace SpiceSharpTest.Algebra
             }
 
             // This should run without throwing an exception
-            Assert.AreEqual(solver.Size, solver.OrderAndFactor());
+            Assert.That(solver.OrderAndFactor(), Is.EqualTo(solver.Size));
         }
 
         [Test]
@@ -223,7 +222,7 @@ namespace SpiceSharpTest.Algebra
             }
 
             // Solver
-            Assert.AreEqual(solver.Size, solver.OrderAndFactor());
+            Assert.That(solver.OrderAndFactor(), Is.EqualTo(solver.Size));
             var solution = new DenseVector<Complex>(solver.Size);
             solver.ForwardSubstitute(solution);
             solver.BackwardSubstitute(solution);
@@ -231,8 +230,8 @@ namespace SpiceSharpTest.Algebra
             // Check!
             for (int r = 0; r < reference.Length; r++)
             {
-                Assert.AreEqual(reference[r].Real, solution[r + 1].Real, 1e-12);
-                Assert.AreEqual(reference[r].Imaginary, solution[r + 1].Imaginary, 1e-12);
+                Assert.That(solution[r + 1].Real, Is.EqualTo(reference[r].Real).Within(1e-12));
+                Assert.That(solution[r + 1].Imaginary, Is.EqualTo(reference[r].Imaginary).Within(1e-12));
             }
         }
 
@@ -253,16 +252,16 @@ namespace SpiceSharpTest.Algebra
             solver[3, 4] = 4;
             solver[4, 4] = 1;
 
-            Assert.AreEqual(2, solver.OrderAndFactor());
+            Assert.That(solver.OrderAndFactor(), Is.EqualTo(2));
 
             // We are testing two things here:
             // - First, the solver should not have chosen a pivot in the lower-right submatrix
             // - Second, the submatrix should be equal to A_cc - A_c1 * A^-1 * A_1c with A the top-left 
             //   matrix, A_cc the bottom-right submatrix, A_1c and A_c1 the off-diagonal matrices
-            Assert.AreEqual(2.0, solver[3, 3], 1e-12);
-            Assert.AreEqual(4.0, solver[3, 4], 1e-12);
-            Assert.AreEqual(-8.0, solver[4, 3], 1e-12);
-            Assert.AreEqual(1.0, solver[4, 4], 1e-12);
+            Assert.That(solver[3, 3], Is.EqualTo(2.0).Within(1e-12));
+            Assert.That(solver[3, 4], Is.EqualTo(4.0).Within(1e-12));
+            Assert.That(solver[4, 3], Is.EqualTo(-8.0).Within(1e-12));
+            Assert.That(solver[4, 4], Is.EqualTo(1.0).Within(1e-12));
         }
 
         [Test]
@@ -290,14 +289,14 @@ namespace SpiceSharpTest.Algebra
             solution[4] = 0;
             solver.ForwardSubstitute(solution);
             solver.BackwardSubstitute(solution);
-            Assert.AreEqual(1.0, solution[1], 1e-12);
-            Assert.AreEqual(1.0, solution[2], 1e-12);
+            Assert.That(solution[1], Is.EqualTo(1.0).Within(1e-12));
+            Assert.That(solution[2], Is.EqualTo(1.0).Within(1e-12));
             solution[3] = 1.0;
             solution[4] = 2.0;
             solver.ForwardSubstitute(solution);
             solver.BackwardSubstitute(solution);
-            Assert.AreEqual(-7.0, solution[1], 1e-12);
-            Assert.AreEqual(-1.0, solution[2], 1e-12);
+            Assert.That(solution[1], Is.EqualTo(-7.0).Within(1e-12));
+            Assert.That(solution[2], Is.EqualTo(-1.0).Within(1e-12));
         }
     }
 }

--- a/SpiceSharpTest/Algebra/SparseVectorTests.cs
+++ b/SpiceSharpTest/Algebra/SparseVectorTests.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using SpiceSharp.Algebra;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Algebra
 {

--- a/SpiceSharpTest/Algebra/SparseVectorTests.cs
+++ b/SpiceSharpTest/Algebra/SparseVectorTests.cs
@@ -1,6 +1,5 @@
 ﻿using NUnit.Framework;
 using SpiceSharp.Algebra;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Algebra
 {
@@ -38,9 +37,9 @@ namespace SpiceSharpTest.Algebra
                         realk = 2;
 
                     if ((fill & 0x01) != 0)
-                        Assert.AreEqual(k, vector[realk], 1e-12);
+                        Assert.That(vector[realk], Is.EqualTo(k).Within(1e-12));
                     else
-                        Assert.AreEqual(vector.FindElement(realk), null);
+                        Assert.That(vector.FindElement(realk), Is.Null);
                     fill = (fill >> 1) & 0b011111;
                 }
             }
@@ -60,9 +59,9 @@ namespace SpiceSharpTest.Algebra
             for (int i = 1; i <= 3; i++)
             {
                 if (i == index)
-                    Assert.AreEqual(null, vector.FindElement(i));
+                    Assert.That(vector.FindElement(i), Is.EqualTo(null));
                 else
-                    Assert.AreEqual(i, vector.FindElement(i).Value);
+                    Assert.That(vector.FindElement(i).Value, Is.EqualTo(i));
             }
         }
     }

--- a/SpiceSharpTest/BasicExampleTests.cs
+++ b/SpiceSharpTest/BasicExampleTests.cs
@@ -5,6 +5,7 @@ using SpiceSharp.Documentation;
 using SpiceSharp.Simulations;
 using SpiceSharp.Validation;
 using System;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest
 {

--- a/SpiceSharpTest/BasicExampleTests.cs
+++ b/SpiceSharpTest/BasicExampleTests.cs
@@ -5,7 +5,6 @@ using SpiceSharp.Documentation;
 using SpiceSharp.Simulations;
 using SpiceSharp.Validation;
 using System;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest
 {
@@ -290,7 +289,7 @@ namespace SpiceSharpTest
                 }
             }
             // </example_Validation>
-            Assert.AreEqual(1, rules.ViolationCount);
+            Assert.That(rules.ViolationCount, Is.EqualTo(1));
         }
 
         [Test]

--- a/SpiceSharpTest/Circuits/CircuitTests.cs
+++ b/SpiceSharpTest/Circuits/CircuitTests.cs
@@ -1,7 +1,6 @@
 ﻿using NUnit.Framework;
 using SpiceSharp;
 using SpiceSharp.Components;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Circuits
 {
@@ -24,8 +23,8 @@ namespace SpiceSharpTest.Circuits
             ckt.Merge(subckt);
 
             // Test
-            Assert.AreEqual(ckt["Ra"], subckt["Ra"]);
-            Assert.AreEqual(ckt["Rb"], subckt["Rb"]);
+            Assert.That(subckt["Ra"], Is.EqualTo(ckt["Ra"]));
+            Assert.That(subckt["Rb"], Is.EqualTo(ckt["Rb"]));
         }
     }
 }

--- a/SpiceSharpTest/Circuits/CircuitTests.cs
+++ b/SpiceSharpTest/Circuits/CircuitTests.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using SpiceSharp;
 using SpiceSharp.Components;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Circuits
 {

--- a/SpiceSharpTest/Examples/CustomResistor/BiasingBehavior.cs
+++ b/SpiceSharpTest/Examples/CustomResistor/BiasingBehavior.cs
@@ -19,6 +19,7 @@ namespace SpiceSharp.Components.NonlinearResistorBehaviors
         /// Creates a new instance of the <see cref="BiasingBehavior"/> class.
         /// </summary>
         /// <param name="name">The name of the behavior.</param>
+        /// <param name="context">The component binding context.</param>
         public BiasingBehavior(string name, ComponentBindingContext context) : base(name)
         {
             if (context == null)

--- a/SpiceSharpTest/General/GeneratorTests.cs
+++ b/SpiceSharpTest/General/GeneratorTests.cs
@@ -1,7 +1,7 @@
 ﻿using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using SpiceSharp.Attributes;
 using System;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.General
 {
@@ -71,9 +71,9 @@ namespace SpiceSharpTest.General
         {
             var p = new TestParameters();
             p.LowerLimit1 = 1.5;
-            Assert.AreEqual(1.5, p.LowerLimit1, 1e-12);
+            Assert.That(p.LowerLimit1, Is.EqualTo(1.5).Within(1e-12));
             p.LowerLimit1 = 0.5;
-            Assert.AreEqual(1.0, p.LowerLimit1, 1e-12);
+            Assert.That(p.LowerLimit1, Is.EqualTo(1.0).Within(1e-12));
         }
 
         [Test]
@@ -81,9 +81,9 @@ namespace SpiceSharpTest.General
         {
             var p = new TestParameters();
             p.UpperLimit1 = 1.5;
-            Assert.AreEqual(1.0, p.UpperLimit1, 1e-12);
+            Assert.That(p.UpperLimit1, Is.EqualTo(1.0).Within(1e-12));
             p.UpperLimit1 = 0.5;
-            Assert.AreEqual(0.5, p.UpperLimit1, 1e-12);
+            Assert.That(p.UpperLimit1, Is.EqualTo(0.5).Within(1e-12));
         }
     }
 }

--- a/SpiceSharpTest/General/GeneratorTests.cs
+++ b/SpiceSharpTest/General/GeneratorTests.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using SpiceSharp.Attributes;
 using System;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.General
 {

--- a/SpiceSharpTest/General/InheritedTypeDictionaryTests.cs
+++ b/SpiceSharpTest/General/InheritedTypeDictionaryTests.cs
@@ -20,9 +20,9 @@ namespace SpiceSharpTest.General
             d.Add(typeof(A), a);
             d.Add(typeof(B), b);
 
-            Assert.AreEqual(a, d[typeof(A)]);
-            Assert.AreEqual(b, d[typeof(B)]);
-            Assert.AreEqual(b, d[typeof(IB)]);
+            Assert.That(a, Is.EqualTo(d[typeof(A)]));
+            Assert.That(b, Is.EqualTo(d[typeof(B)]));
+            Assert.That(b, Is.EqualTo(d[typeof(IB)]));
             Assert.Throws<AmbiguousTypeException>(() => { object r = d[typeof(IA)]; });
         }
     }

--- a/SpiceSharpTest/Helper.cs
+++ b/SpiceSharpTest/Helper.cs
@@ -1,5 +1,5 @@
-﻿using NUnit.Framework;
-using System;
+﻿using System;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest
 {

--- a/SpiceSharpTest/Helper.cs
+++ b/SpiceSharpTest/Helper.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
+﻿using NUnit.Framework;
+using System;
 
 namespace SpiceSharpTest
 {
@@ -37,7 +37,7 @@ namespace SpiceSharpTest
         /// <param name="absTol">The absolute tolerance.</param>
         public static void AreEqual(double reference, double actual, double relTol = DefaultRelativeTolerance, double absTol = DefaultAbsoluteTolerance)
         {
-            Assert.AreEqual(reference, actual, Tolerance(reference, actual, relTol, absTol));
+            Assert.That(actual, Is.EqualTo(reference).Within(Tolerance(reference, actual, relTol, absTol)));
         }
     }
 }

--- a/SpiceSharpTest/Models/Currentsources/CCCS/CurrentControlledCurrentSourceTests.cs
+++ b/SpiceSharpTest/Models/Currentsources/CCCS/CurrentControlledCurrentSourceTests.cs
@@ -6,7 +6,6 @@ using SpiceSharp.Validation;
 using System;
 using System.Linq;
 using System.Numerics;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {
@@ -71,10 +70,10 @@ namespace SpiceSharpTest.Models
             // Make the simulation and run it
             var op = new OP("op");
             var ex = Assert.Throws<ValidationFailedException>(() => op.Run(ckt));
-            Assert.AreEqual(1, ex.Rules.ViolationCount);
+            Assert.That(ex.Rules.ViolationCount, Is.EqualTo(1));
             var violation = ex.Rules.Violations.First();
-            Assert.IsInstanceOf<FloatingNodeRuleViolation>(violation);
-            Assert.AreEqual("out", ((FloatingNodeRuleViolation)violation).FloatingVariable.Name);
+            Assert.That(violation, Is.InstanceOf<FloatingNodeRuleViolation>());
+            Assert.That(((FloatingNodeRuleViolation)violation).FloatingVariable.Name, Is.EqualTo("out"));
         }
 
         [Test]

--- a/SpiceSharpTest/Models/Currentsources/CCCS/CurrentControlledCurrentSourceTests.cs
+++ b/SpiceSharpTest/Models/Currentsources/CCCS/CurrentControlledCurrentSourceTests.cs
@@ -4,9 +4,9 @@ using SpiceSharp.Components;
 using SpiceSharp.Simulations;
 using SpiceSharp.Validation;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {

--- a/SpiceSharpTest/Models/Currentsources/ISRC/CurrentSourceTests.cs
+++ b/SpiceSharpTest/Models/Currentsources/ISRC/CurrentSourceTests.cs
@@ -3,7 +3,6 @@ using SpiceSharp;
 using SpiceSharp.Components;
 using SpiceSharp.Simulations;
 using System.Collections.Generic;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {
@@ -58,7 +57,7 @@ namespace SpiceSharpTest.Models
         /// <returns></returns>
         static Circuit CreateResistorsInSeriesCircuit(int count, double current, double resistance)
         {
-            Assert.IsTrue(count > 1);
+            Assert.That(count > 1);
             var ckt = new Circuit(
                 new CurrentSource("I1", "IN", "0", current),
                 new Resistor("R1", "IN", "B1", resistance),
@@ -131,17 +130,17 @@ namespace SpiceSharpTest.Models
             isrc.GetProperty<IWaveformDescription>("waveform").SetParameter("v2", 2.0);
 
             // Check
-            Assert.AreEqual(isrc.Name, clone.Name);
+            Assert.That(clone.Name, Is.EqualTo(isrc.Name));
             var origNodes = isrc.Nodes;
             var cloneNodes = clone.Nodes;
-            Assert.AreEqual(origNodes[0], cloneNodes[0]);
-            Assert.AreEqual(origNodes[1], cloneNodes[1]);
+            Assert.That(cloneNodes[0], Is.EqualTo(origNodes[0]));
+            Assert.That(cloneNodes[1], Is.EqualTo(origNodes[1]));
             var waveform = (Pulse)clone.GetProperty<IWaveformDescription>("waveform");
-            Assert.AreEqual(0.0, waveform.InitialValue, 1e-12);
-            Assert.AreEqual(1.0, waveform.PulsedValue, 1e-12);
-            Assert.AreEqual(2.0, isrc.GetProperty<IWaveformDescription>("waveform").GetProperty<double>("v2"));
-            Assert.AreEqual(1.0, waveform.GetProperty<double>("v2"));
-            Assert.AreEqual(1e-5, waveform.GetProperty<double>("per"), 1e-12);
+            Assert.That(waveform.InitialValue, Is.EqualTo(0.0).Within(1e-12));
+            Assert.That(waveform.PulsedValue, Is.EqualTo(1.0).Within(1e-12));
+            Assert.That(isrc.GetProperty<IWaveformDescription>("waveform").GetProperty<double>("v2"), Is.EqualTo(2.0));
+            Assert.That(waveform.GetProperty<double>("v2"), Is.EqualTo(1.0));
+            Assert.That(waveform.GetProperty<double>("per"), Is.EqualTo(1e-5).Within(1e-12));
         }
 
         [Test]

--- a/SpiceSharpTest/Models/Currentsources/ISRC/CurrentSourceTests.cs
+++ b/SpiceSharpTest/Models/Currentsources/ISRC/CurrentSourceTests.cs
@@ -3,6 +3,7 @@ using SpiceSharp;
 using SpiceSharp.Components;
 using SpiceSharp.Simulations;
 using System.Collections.Generic;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {

--- a/SpiceSharpTest/Models/Currentsources/VCCS/VoltageControlledCurrentSourceTests.cs
+++ b/SpiceSharpTest/Models/Currentsources/VCCS/VoltageControlledCurrentSourceTests.cs
@@ -6,7 +6,6 @@ using SpiceSharp.Validation;
 using System;
 using System.Linq;
 using System.Numerics;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {
@@ -69,7 +68,7 @@ namespace SpiceSharpTest.Models
 
             var op = new OP("op1");
             var current = new RealPropertyExport(op, "G1", "i");
-            op.ExportSimulationData += (sender, args) => Assert.AreEqual(300.0, current.Value, 1e-12);
+            op.ExportSimulationData += (sender, args) => Assert.That(current.Value, Is.EqualTo(300.0).Within(1e-12));
             op.Run(ckt);
             current.Destroy();
         }
@@ -85,12 +84,12 @@ namespace SpiceSharpTest.Models
             // Make the simulation and run it
             var dc = new OP("op");
             var ex = Assert.Throws<ValidationFailedException>(() => dc.Run(ckt));
-            Assert.AreEqual(2, ex.Rules.ViolationCount);
+            Assert.That(ex.Rules.ViolationCount, Is.EqualTo(2));
             var violations = ex.Rules.Violations.ToArray();
-            Assert.IsInstanceOf<FloatingNodeRuleViolation>(violations[0]);
-            Assert.AreEqual("out", ((FloatingNodeRuleViolation)violations[0]).FloatingVariable.Name);
-            Assert.IsInstanceOf<FloatingNodeRuleViolation>(violations[1]);
-            Assert.AreEqual("in", ((FloatingNodeRuleViolation)violations[1]).FloatingVariable.Name);
+            Assert.That(violations[0], Is.InstanceOf<FloatingNodeRuleViolation>());
+            Assert.That(((FloatingNodeRuleViolation)violations[0]).FloatingVariable.Name, Is.EqualTo("out"));
+            Assert.That(violations[1], Is.InstanceOf<FloatingNodeRuleViolation>());
+            Assert.That(((FloatingNodeRuleViolation)violations[1]).FloatingVariable.Name, Is.EqualTo("in"));
         }
 
         [Test]

--- a/SpiceSharpTest/Models/Currentsources/VCCS/VoltageControlledCurrentSourceTests.cs
+++ b/SpiceSharpTest/Models/Currentsources/VCCS/VoltageControlledCurrentSourceTests.cs
@@ -6,6 +6,7 @@ using SpiceSharp.Validation;
 using System;
 using System.Linq;
 using System.Numerics;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {

--- a/SpiceSharpTest/Models/Framework.cs
+++ b/SpiceSharpTest/Models/Framework.cs
@@ -10,6 +10,7 @@ using System.Globalization;
 using System.Linq;
 using System.Numerics;
 using System.Text.RegularExpressions;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {

--- a/SpiceSharpTest/Models/Framework.cs
+++ b/SpiceSharpTest/Models/Framework.cs
@@ -10,7 +10,6 @@ using System.Globalization;
 using System.Linq;
 using System.Numerics;
 using System.Text.RegularExpressions;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {
@@ -147,7 +146,7 @@ namespace SpiceSharpTest.Models
                     double expected = results[index++];
                     double actual = export.Value;
                     double tol = Math.Max(Math.Abs(expected), Math.Abs(actual)) * CompareRelTol + CompareAbsTol;
-                    Assert.AreEqual(expected, actual, tol);
+                    Assert.That(actual, Is.EqualTo(expected).Within(tol));
                 }
             }
 
@@ -185,9 +184,9 @@ namespace SpiceSharpTest.Models
                     var expected = results[index++];
                     var actual = export.Value;
                     double tol = Math.Max(Math.Abs(expected.Real), Math.Abs(actual.Real)) * CompareRelTol + CompareAbsTol;
-                    Assert.AreEqual(expected.Real, actual.Real, tol);
+                    Assert.That(actual.Real, Is.EqualTo(expected.Real).Within(tol));
                     tol = Math.Max(Math.Abs(expected.Imaginary), Math.Abs(actual.Imaginary)) * CompareRelTol + CompareAbsTol;
-                    Assert.AreEqual(expected.Imaginary, actual.Imaginary, tol);
+                    Assert.That(actual.Imaginary, Is.EqualTo(expected.Imaginary).Within(tol));
                 }
             }
 
@@ -225,7 +224,7 @@ namespace SpiceSharpTest.Models
                     double actual = exportIt.Current?.Value ?? throw new ArgumentNullException();
                     double expected = referencesIt.Current;
                     double tol = Math.Max(Math.Abs(actual), Math.Abs(expected)) * RelTol + AbsTol;
-                    Assert.AreEqual(expected, actual, tol);
+                    Assert.That(actual, Is.EqualTo(expected).Within(tol));
                 }
             };
             sim.Run(ckt);
@@ -258,7 +257,7 @@ namespace SpiceSharpTest.Models
 
                     try
                     {
-                        Assert.AreEqual(expected, actual, tol);
+                        Assert.That(actual, Is.EqualTo(expected).Within(tol));
                     }
                     catch (Exception ex)
                     {
@@ -298,7 +297,7 @@ namespace SpiceSharpTest.Models
 
                     try
                     {
-                        Assert.AreEqual(expected, actual, tol);
+                        Assert.That(actual, Is.EqualTo(expected).Within(tol));
                     }
                     catch (Exception ex)
                     {
@@ -338,7 +337,7 @@ namespace SpiceSharpTest.Models
 
                     try
                     {
-                        Assert.AreEqual(expected, actual, tol);
+                        Assert.That(actual, Is.EqualTo(expected).Within(tol));
                     }
                     catch (Exception ex)
                     {
@@ -379,8 +378,8 @@ namespace SpiceSharpTest.Models
 
                     try
                     {
-                        Assert.AreEqual(expected.Real, actual.Real, rtol);
-                        Assert.AreEqual(expected.Imaginary, actual.Imaginary, itol);
+                        Assert.That(actual.Real, Is.EqualTo(expected.Real).Within(rtol));
+                        Assert.That(actual.Imaginary, Is.EqualTo(expected.Imaginary).Within(itol));
                     }
                     catch (Exception ex)
                     {
@@ -420,8 +419,8 @@ namespace SpiceSharpTest.Models
 
                     try
                     {
-                        Assert.AreEqual(expected.Real, actual.Real, rtol);
-                        Assert.AreEqual(expected.Imaginary, actual.Imaginary, itol);
+                        Assert.That(actual.Real, Is.EqualTo(expected.Real).Within(rtol));
+                        Assert.That(actual.Imaginary, Is.EqualTo(expected.Imaginary).Within(itol));
                     }
                     catch (Exception ex)
                     {
@@ -455,7 +454,7 @@ namespace SpiceSharpTest.Models
 
                     try
                     {
-                        Assert.AreEqual(expected, actual, tol);
+                        Assert.That(actual, Is.EqualTo(expected).Within(tol));
                     }
                     catch (Exception ex)
                     {
@@ -491,7 +490,7 @@ namespace SpiceSharpTest.Models
 
                     try
                     {
-                        Assert.AreEqual(expected, actual, tol);
+                        Assert.That(actual, Is.EqualTo(expected).Within(tol));
                     }
                     catch (Exception ex)
                     {
@@ -526,7 +525,7 @@ namespace SpiceSharpTest.Models
 
                     try
                     {
-                        Assert.AreEqual(expected, actual, tol);
+                        Assert.That(actual, Is.EqualTo(expected).Within(tol));
                     }
                     catch (Exception ex)
                     {

--- a/SpiceSharpTest/Models/Parallel/SimpleParallelTests.cs
+++ b/SpiceSharpTest/Models/Parallel/SimpleParallelTests.cs
@@ -8,6 +8,7 @@ using SpiceSharp.Simulations;
 using System;
 using System.Collections.Generic;
 using System.Numerics;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {

--- a/SpiceSharpTest/Models/Parallel/SimpleParallelTests.cs
+++ b/SpiceSharpTest/Models/Parallel/SimpleParallelTests.cs
@@ -8,7 +8,6 @@ using SpiceSharp.Simulations;
 using System;
 using System.Collections.Generic;
 using System.Numerics;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {
@@ -205,7 +204,7 @@ namespace SpiceSharpTest.Models
             var watch = System.Diagnostics.Stopwatch.StartNew();
             dc.Run(solveCirc);
             watch.Stop();
-            Assert.AreNotEqual(0.0, maxPower);
+            Assert.That(maxPower, Is.Not.EqualTo(0.0));
         }
 
         public static IEnumerable<TestCaseData> WorkDistributor

--- a/SpiceSharpTest/Models/RLC/IND/InductorTests.cs
+++ b/SpiceSharpTest/Models/RLC/IND/InductorTests.cs
@@ -7,6 +7,7 @@ using SpiceSharp.Validation;
 using System;
 using System.Linq;
 using System.Numerics;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {

--- a/SpiceSharpTest/Models/RLC/IND/InductorTests.cs
+++ b/SpiceSharpTest/Models/RLC/IND/InductorTests.cs
@@ -7,7 +7,6 @@ using SpiceSharp.Validation;
 using System;
 using System.Linq;
 using System.Numerics;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {
@@ -123,9 +122,9 @@ namespace SpiceSharpTest.Models
 
             var op = new OP("op");
             var ex = Assert.Throws<ValidationFailedException>(() => op.Run(ckt));
-            Assert.AreEqual(1, ex.Rules.ViolationCount);
+            Assert.That(ex.Rules.ViolationCount, Is.EqualTo(1));
             var violation = ex.Rules.Violations.First();
-            Assert.IsInstanceOf<VoltageLoopRuleViolation>(violation);
+            Assert.That(violation, Is.InstanceOf<VoltageLoopRuleViolation>());
         }
 
         [Test]

--- a/SpiceSharpTest/Models/RLC/RES/ResistorTests.cs
+++ b/SpiceSharpTest/Models/RLC/RES/ResistorTests.cs
@@ -4,6 +4,7 @@ using SpiceSharp.Components;
 using SpiceSharp.Simulations;
 using System;
 using System.Numerics;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {

--- a/SpiceSharpTest/Models/RLC/RES/ResistorTests.cs
+++ b/SpiceSharpTest/Models/RLC/RES/ResistorTests.cs
@@ -4,7 +4,6 @@ using SpiceSharp.Components;
 using SpiceSharp.Simulations;
 using System;
 using System.Numerics;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {
@@ -22,7 +21,7 @@ namespace SpiceSharpTest.Models
             {
                 var solver = op.GetState<IBiasingSimulationState>().Solver;
                 var elt = solver.FindElement(new SpiceSharp.Algebra.MatrixLocation(1, 1));
-                Assert.AreEqual(1.0 / SpiceSharp.Components.Resistors.Parameters.MinimumResistance, elt.Value, 1e-20);
+                Assert.That(elt.Value, Is.EqualTo(1.0 / SpiceSharp.Components.Resistors.Parameters.MinimumResistance).Within(1e-20));
             };
             op.Run(ckt);
         }
@@ -293,8 +292,8 @@ namespace SpiceSharpTest.Models
             noise.ExportSimulationData += (sender, args) =>
             {
                 // We expect 4*k*T*R noise variance
-                Assert.AreEqual(4 * Constants.Boltzmann * temp * 1e3, onoise.Value, 1e-20);
-                Assert.AreEqual(4 * Constants.Boltzmann * temp / 1e3, inoise.Value, 1e-20);
+                Assert.That(onoise.Value, Is.EqualTo(4 * Constants.Boltzmann * temp * 1e3).Within(1e-20));
+                Assert.That(inoise.Value, Is.EqualTo(4 * Constants.Boltzmann * temp / 1e3).Within(1e-20));
             };
             noise.Run(ckt);
         }

--- a/SpiceSharpTest/Models/Sampler/SamplerTests.cs
+++ b/SpiceSharpTest/Models/Sampler/SamplerTests.cs
@@ -3,7 +3,6 @@ using SpiceSharp;
 using SpiceSharp.Components;
 using SpiceSharp.Simulations;
 using System.Collections.Generic;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {
@@ -33,12 +32,13 @@ namespace SpiceSharpTest.Models
                 {
                     if (!refPoints.MoveNext())
                         throw new SpiceSharpException("Reference points already ended");
-                    Assert.AreEqual(args.Time, refPoints.Current, 1e-9);
+                    Assert.That(refPoints.Current, Is.EqualTo(args.Time).Within(1e-9));
                 }));
             var tran = new Transient("tran", 1e-6, 1);
             tran.Run(ckt);
 
             // Make sure we went through all our reference points
-            Assert.IsFalse(refPoints.MoveNext());        }
+            Assert.That(refPoints.MoveNext(), Is.False);
+        }
     }
 }

--- a/SpiceSharpTest/Models/Sampler/SamplerTests.cs
+++ b/SpiceSharpTest/Models/Sampler/SamplerTests.cs
@@ -3,6 +3,7 @@ using SpiceSharp;
 using SpiceSharp.Components;
 using SpiceSharp.Simulations;
 using System.Collections.Generic;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {

--- a/SpiceSharpTest/Models/Semiconductors/DIO/DiodeTests.cs
+++ b/SpiceSharpTest/Models/Semiconductors/DIO/DiodeTests.cs
@@ -4,7 +4,6 @@ using SpiceSharp.Components;
 using SpiceSharp.Simulations;
 using System;
 using System.Numerics;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {
@@ -51,7 +50,7 @@ namespace SpiceSharpTest.Models
 
                 // Because the property is always one iteration behind on the current solution, we relax the error a little bit
                 double tol = Math.Max(Math.Abs(voltage), Math.Abs(voltage2)) * RelTol + 1e-9;
-                Assert.AreEqual(voltage2, voltage, tol);
+                Assert.That(voltage, Is.EqualTo(voltage2).Within(tol));
             };
             dc.Run(ckt);
         }
@@ -344,7 +343,7 @@ namespace SpiceSharpTest.Models
             tran.ExportSimulationData += (sender, args) =>
             {
                 double tol = Math.Max(Math.Abs(v_ref.Value), Math.Abs(v_act.Value)) * CompareRelTol + CompareAbsTol;
-                Assert.AreEqual(v_ref.Value, v_act.Value, tol);
+                Assert.That(v_act.Value, Is.EqualTo(v_ref.Value).Within(tol));
             };
             tran.Run(ckt);
             v_ref.Destroy();

--- a/SpiceSharpTest/Models/Semiconductors/DIO/DiodeTests.cs
+++ b/SpiceSharpTest/Models/Semiconductors/DIO/DiodeTests.cs
@@ -4,6 +4,7 @@ using SpiceSharp.Components;
 using SpiceSharp.Simulations;
 using System;
 using System.Numerics;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {

--- a/SpiceSharpTest/Models/Semiconductors/Mosfet/Level1/MOS1Tests.cs
+++ b/SpiceSharpTest/Models/Semiconductors/Mosfet/Level1/MOS1Tests.cs
@@ -4,7 +4,6 @@ using SpiceSharp.Components;
 using SpiceSharp.Simulations;
 using System;
 using System.Numerics;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {
@@ -487,7 +486,7 @@ namespace SpiceSharpTest.Models
             tran.ExportSimulationData += (sender, args) =>
             {
                 double tol = Math.Max(Math.Abs(v_ref.Value), Math.Abs(v_act.Value)) * CompareRelTol + CompareAbsTol;
-                Assert.AreEqual(v_ref.Value, v_act.Value, tol);
+                Assert.That(v_act.Value, Is.EqualTo(v_ref.Value).Within(tol));
             };
             tran.Run(ckt);
         }

--- a/SpiceSharpTest/Models/Semiconductors/Mosfet/Level1/MOS1Tests.cs
+++ b/SpiceSharpTest/Models/Semiconductors/Mosfet/Level1/MOS1Tests.cs
@@ -4,6 +4,7 @@ using SpiceSharp.Components;
 using SpiceSharp.Simulations;
 using System;
 using System.Numerics;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {

--- a/SpiceSharpTest/Models/Semiconductors/Mosfet/Level2/MOS2Tests.cs
+++ b/SpiceSharpTest/Models/Semiconductors/Mosfet/Level2/MOS2Tests.cs
@@ -4,7 +4,6 @@ using SpiceSharp.Components;
 using SpiceSharp.Simulations;
 using System;
 using System.Numerics;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {
@@ -416,7 +415,7 @@ namespace SpiceSharpTest.Models
             tran.ExportSimulationData += (sender, args) =>
             {
                 double tol = Math.Max(Math.Abs(v_ref.Value), Math.Abs(v_act.Value)) * CompareRelTol + CompareAbsTol;
-                Assert.AreEqual(v_ref.Value, v_act.Value, tol);
+                Assert.That(v_act.Value, Is.EqualTo(v_ref.Value).Within(tol));
             };
             tran.Run(ckt);
         }

--- a/SpiceSharpTest/Models/Semiconductors/Mosfet/Level2/MOS2Tests.cs
+++ b/SpiceSharpTest/Models/Semiconductors/Mosfet/Level2/MOS2Tests.cs
@@ -4,6 +4,7 @@ using SpiceSharp.Components;
 using SpiceSharp.Simulations;
 using System;
 using System.Numerics;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {

--- a/SpiceSharpTest/Models/Semiconductors/Mosfet/Level3/MOS3Tests.cs
+++ b/SpiceSharpTest/Models/Semiconductors/Mosfet/Level3/MOS3Tests.cs
@@ -4,6 +4,7 @@ using SpiceSharp.Components;
 using SpiceSharp.Simulations;
 using System;
 using System.Numerics;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {

--- a/SpiceSharpTest/Models/Semiconductors/Mosfet/Level3/MOS3Tests.cs
+++ b/SpiceSharpTest/Models/Semiconductors/Mosfet/Level3/MOS3Tests.cs
@@ -4,7 +4,6 @@ using SpiceSharp.Components;
 using SpiceSharp.Simulations;
 using System;
 using System.Numerics;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {
@@ -377,7 +376,7 @@ namespace SpiceSharpTest.Models
             tran.ExportSimulationData += (sender, args) =>
             {
                 double tol = Math.Max(Math.Abs(v_ref.Value), Math.Abs(v_act.Value)) * CompareRelTol + CompareAbsTol;
-                Assert.AreEqual(v_ref.Value, v_act.Value, tol);
+                Assert.That(v_act.Value, Is.EqualTo(v_ref.Value).Within(tol));
             };
             tran.Run(ckt);
             v_ref.Destroy();

--- a/SpiceSharpTest/Models/Subcircuits/SimpleSubcircuitTests.cs
+++ b/SpiceSharpTest/Models/Subcircuits/SimpleSubcircuitTests.cs
@@ -1,11 +1,11 @@
 ﻿using NUnit.Framework;
 using SpiceSharp;
-using SpiceSharp.Behaviors;
 using SpiceSharp.Components;
 using SpiceSharp.Simulations;
 using System;
 using System.Collections.Generic;
 using System.Numerics;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {

--- a/SpiceSharpTest/Models/Subcircuits/SimpleSubcircuitTests.cs
+++ b/SpiceSharpTest/Models/Subcircuits/SimpleSubcircuitTests.cs
@@ -5,7 +5,6 @@ using SpiceSharp.Simulations;
 using System;
 using System.Collections.Generic;
 using System.Numerics;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {
@@ -297,10 +296,10 @@ namespace SpiceSharpTest.Models
             var op = new OP("op");
             op.Run(ckt);
             var behaviors = op.EntityBehaviors["X2"].GetValue<SpiceSharp.Components.Subcircuits.EntitiesBehavior>();
-            Assert.AreEqual(10.0 / 4.0, behaviors.LocalBehaviors["R2"].GetProperty<double>("v"), 1e-12);
+            Assert.That(behaviors.LocalBehaviors["R2"].GetProperty<double>("v"), Is.EqualTo(10.0 / 4.0).Within(1e-12));
 
             var state = behaviors.GetState<IBiasingSimulationState>();
-            Assert.AreEqual(10.0 / 4.0, state.Solution[state.Map[state.GetSharedVariable("b")]], 1e-12);
+            Assert.That(state.Solution[state.Map[state.GetSharedVariable("b")]], Is.EqualTo(10.0 / 4.0).Within(1e-12));
         }
     }
 }

--- a/SpiceSharpTest/Models/Subcircuits/SubcircuitLocalSolverTests.cs
+++ b/SpiceSharpTest/Models/Subcircuits/SubcircuitLocalSolverTests.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {

--- a/SpiceSharpTest/Models/Subcircuits/SubcircuitLocalSolverTests.cs
+++ b/SpiceSharpTest/Models/Subcircuits/SubcircuitLocalSolverTests.cs
@@ -8,7 +8,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {
@@ -170,7 +169,7 @@ namespace SpiceSharpTest.Models
             var op = new OP("op");
             op.ExportSimulationData += (sender, args) =>
             {
-                Assert.AreEqual(1.0e3, args.GetVoltage("x"));
+                Assert.That(args.GetVoltage("x"), Is.EqualTo(1.0e3));
             };
             op.Run(ckt);
         }
@@ -190,7 +189,7 @@ namespace SpiceSharpTest.Models
             var op = new OP("op");
             op.ExportSimulationData += (sender, args) =>
             {
-                Assert.AreEqual(1.0e3, args.GetVoltage("x"));
+                Assert.That(args.GetVoltage("x"), Is.EqualTo(1.0e3));
             };
             op.Run(ckt);
         }
@@ -214,7 +213,7 @@ namespace SpiceSharpTest.Models
             var op = new OP("op");
             op.ExportSimulationData += (sender, args) =>
             {
-                Assert.AreEqual(0.5e3, args.GetVoltage("x"));
+                Assert.That(args.GetVoltage("x"), Is.EqualTo(0.5e3));
             };
             op.Run(ckt);
         }
@@ -231,7 +230,7 @@ namespace SpiceSharpTest.Models
             var op = new OP("op");
             op.ExportSimulationData += (sender, args) =>
             {
-                Assert.AreEqual(0.5, args.GetVoltage("x"));
+                Assert.That(args.GetVoltage("x"), Is.EqualTo(0.5));
             };
             op.Run(ckt);
         }
@@ -252,7 +251,7 @@ namespace SpiceSharpTest.Models
             var op = new OP("op");
             op.ExportSimulationData += (sender, args) =>
             {
-                Assert.AreEqual(0.5, args.GetVoltage("x"));
+                Assert.That(args.GetVoltage("x"), Is.EqualTo(0.5));
             };
             op.Run(ckt);
         }
@@ -558,8 +557,8 @@ namespace SpiceSharpTest.Models
 
             var exportsExpected = buildExports(opExpected);
             var exportsActual = buildExports(opActual);
-            Assert.AreEqual(exportsExpected.Length, exportsActual.Length);
-            Assert.Greater(exportsExpected.Length, 0);
+            Assert.That(exportsActual.Length, Is.EqualTo(exportsExpected.Length));
+            Assert.That(exportsExpected.Length, Is.GreaterThan(0));
 
             // Simulate the expected values
             double[] expected = new double[exportsExpected.Length];
@@ -579,12 +578,12 @@ namespace SpiceSharpTest.Models
                 {
                     double actual = exportsActual[i].Value;
                     double tol = Math.Max(Math.Abs(actual), Math.Abs(expected[i])) * parameters.RelativeTolerance + parameters.AbsoluteTolerance;
-                    Assert.AreEqual(expected[i], actual, tol);
+                    Assert.That(actual, Is.EqualTo(expected[i]).Within(tol));
                 }
                 didCheck = true;
             };
             opActual.Run(cktActual);
-            Assert.True(didCheck);
+            Assert.That(didCheck);
 
             DestroyExports(exportsExpected);
             DestroyExports(exportsActual);
@@ -608,8 +607,8 @@ namespace SpiceSharpTest.Models
 
             var exportsExpected = buildExports(opExpected);
             var exportsActual = buildExports(opActual);
-            Assert.AreEqual(exportsExpected.Length, exportsActual.Length);
-            Assert.Greater(exportsExpected.Length, 0);
+            Assert.That(exportsActual.Length, Is.EqualTo(exportsExpected.Length));
+            Assert.That(exportsExpected.Length, Is.GreaterThan(0));
 
             // Simulate the expected values
             var expected = new Complex[points][];
@@ -632,14 +631,14 @@ namespace SpiceSharpTest.Models
                 {
                     var actual = exportsActual[i].Value;
                     double tol = Math.Max(Math.Abs(actual.Real), Math.Abs(expected[index][i].Real)) * 1e-6 + 1e-12;
-                    Assert.AreEqual(expected[index][i].Real, actual.Real, tol);
+                    Assert.That(actual.Real, Is.EqualTo(expected[index][i].Real).Within(tol));
                     tol = Math.Max(Math.Abs(actual.Imaginary), Math.Abs(expected[index][i].Imaginary)) * 1e-6 + 1e-12;
-                    Assert.AreEqual(expected[index][i].Imaginary, actual.Imaginary, tol);
+                    Assert.That(actual.Imaginary, Is.EqualTo(expected[index][i].Imaginary).Within(tol));
                 }
                 index++;
             };
             opActual.Run(cktActual);
-            Assert.AreEqual(points, index);
+            Assert.That(index, Is.EqualTo(points));
 
             DestroyExports(exportsExpected);
             DestroyExports(exportsActual);
@@ -665,8 +664,8 @@ namespace SpiceSharpTest.Models
 
             var exportsExpected = buildExports(opExpected);
             var exportsActual = buildExports(opActual);
-            Assert.AreEqual(exportsExpected.Length, exportsActual.Length);
-            Assert.Greater(exportsExpected.Length, 0);
+            Assert.That(exportsActual.Length, Is.EqualTo(exportsExpected.Length));
+            Assert.That(exportsExpected.Length, Is.GreaterThan(0));
 
             // Simulate the expected values
             double[][] expected = new double[points][];
@@ -689,12 +688,12 @@ namespace SpiceSharpTest.Models
                 {
                     double actual = exportsActual[i].Value;
                     double tol = Math.Max(Math.Abs(actual), Math.Abs(expected[index][i])) * 1e-6;
-                    Assert.AreEqual(expected[index][i], actual, tol);
+                    Assert.That(actual, Is.EqualTo(expected[index][i]).Within(tol));
                 }
                 index++;
             };
             opActual.Run(cktActual);
-            Assert.AreEqual(points, index);
+            Assert.That(index, Is.EqualTo(points));
 
             DestroyExports(exportsExpected);
             DestroyExports(exportsActual);

--- a/SpiceSharpTest/Models/Switches/CSW/CurrentSwitchTests.cs
+++ b/SpiceSharpTest/Models/Switches/CSW/CurrentSwitchTests.cs
@@ -4,7 +4,6 @@ using SpiceSharp.Components;
 using SpiceSharp.Simulations;
 using System;
 using System.Numerics;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {
@@ -306,11 +305,11 @@ namespace SpiceSharpTest.Models
 
             // Check on
             s.SetParameter("on", true);
-            Assert.AreEqual(true, p.ZeroState);
+            Assert.That(p.ZeroState, Is.EqualTo(true));
 
             // Check off
             s.SetParameter("off", true);
-            Assert.AreEqual(false, p.ZeroState);
+            Assert.That(p.ZeroState, Is.EqualTo(false));
         }
 
         [Test]

--- a/SpiceSharpTest/Models/Switches/CSW/CurrentSwitchTests.cs
+++ b/SpiceSharpTest/Models/Switches/CSW/CurrentSwitchTests.cs
@@ -4,6 +4,7 @@ using SpiceSharp.Components;
 using SpiceSharp.Simulations;
 using System;
 using System.Numerics;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {

--- a/SpiceSharpTest/Models/Switches/VSW/VoltageSwitchTests.cs
+++ b/SpiceSharpTest/Models/Switches/VSW/VoltageSwitchTests.cs
@@ -6,7 +6,6 @@ using SpiceSharp.Validation;
 using System;
 using System.Linq;
 using System.Numerics;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {
@@ -305,11 +304,11 @@ namespace SpiceSharpTest.Models
 
             // Check on
             s.SetParameter("on", true);
-            Assert.AreEqual(true, p.ZeroState);
+            Assert.That(p.ZeroState, Is.EqualTo(true));
 
             // Check off
             s.SetParameter("off", true);
-            Assert.AreEqual(false, p.ZeroState);
+            Assert.That(p.ZeroState, Is.EqualTo(false));
         }
 
         [Test]
@@ -322,10 +321,10 @@ namespace SpiceSharpTest.Models
             // Make the simulation and run it
             var op = new OP("op");
             var ex = Assert.Throws<ValidationFailedException>(() => op.Run(ckt));
-            Assert.AreEqual(1, ex.Rules.ViolationCount);
+            Assert.That(ex.Rules.ViolationCount, Is.EqualTo(1));
             var violation = ex.Rules.Violations.First();
-            Assert.IsInstanceOf<FloatingNodeRuleViolation>(violation);
-            Assert.AreEqual("in", ((FloatingNodeRuleViolation)violation).FloatingVariable.Name);
+            Assert.That(violation, Is.InstanceOf<FloatingNodeRuleViolation>());
+            Assert.That(((FloatingNodeRuleViolation)violation).FloatingVariable.Name, Is.EqualTo("in"));
         }
 
         [Test]

--- a/SpiceSharpTest/Models/Switches/VSW/VoltageSwitchTests.cs
+++ b/SpiceSharpTest/Models/Switches/VSW/VoltageSwitchTests.cs
@@ -6,6 +6,7 @@ using SpiceSharp.Validation;
 using System;
 using System.Linq;
 using System.Numerics;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {

--- a/SpiceSharpTest/Models/Voltagesources/CCVS/CurrentControlledVoltageSourceTests.cs
+++ b/SpiceSharpTest/Models/Voltagesources/CCVS/CurrentControlledVoltageSourceTests.cs
@@ -6,6 +6,7 @@ using SpiceSharp.Validation;
 using System;
 using System.Linq;
 using System.Numerics;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {

--- a/SpiceSharpTest/Models/Voltagesources/CCVS/CurrentControlledVoltageSourceTests.cs
+++ b/SpiceSharpTest/Models/Voltagesources/CCVS/CurrentControlledVoltageSourceTests.cs
@@ -6,7 +6,6 @@ using SpiceSharp.Validation;
 using System;
 using System.Linq;
 using System.Numerics;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {
@@ -64,9 +63,9 @@ namespace SpiceSharpTest.Models
                 new CurrentControlledVoltageSource("F2", "0", "out", "V1", 2.0));
             var op = new OP("op");
             var ex = Assert.Throws<ValidationFailedException>(() => op.Run(ckt));
-            Assert.AreEqual(1, ex.Rules.ViolationCount);
+            Assert.That(ex.Rules.ViolationCount, Is.EqualTo(1));
             var violation = ex.Rules.Violations.First();
-            Assert.IsInstanceOf<VoltageLoopRuleViolation>(violation);
+            Assert.That(violation, Is.InstanceOf<VoltageLoopRuleViolation>());
         }
 
         [Test]
@@ -79,9 +78,9 @@ namespace SpiceSharpTest.Models
                 new CurrentControlledVoltageSource("F3", "out2", "0", "V1", 3.0));
             var op = new OP("op");
             var ex = Assert.Throws<ValidationFailedException>(() => op.Run(ckt));
-            Assert.AreEqual(1, ex.Rules.ViolationCount);
+            Assert.That(ex.Rules.ViolationCount, Is.EqualTo(1));
             var violation = ex.Rules.Violations.First();
-            Assert.IsInstanceOf<VoltageLoopRuleViolation>(violation);
+            Assert.That(violation, Is.InstanceOf<VoltageLoopRuleViolation>());
         }
 
         /*

--- a/SpiceSharpTest/Models/Voltagesources/VCVS/VoltageControlledVoltageSourceTests.cs
+++ b/SpiceSharpTest/Models/Voltagesources/VCVS/VoltageControlledVoltageSourceTests.cs
@@ -6,7 +6,6 @@ using SpiceSharp.Validation;
 using System;
 using System.Linq;
 using System.Numerics;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {
@@ -60,8 +59,8 @@ namespace SpiceSharpTest.Models
                 new VoltageControlledVoltageSource("E1", "out", "0", "in", "0", 1.0));
             var op = new OP("op");
             var ex = Assert.Throws<ValidationFailedException>(() => op.Run(ckt));
-            Assert.AreEqual(1, ex.Rules.ViolationCount);
-            Assert.IsInstanceOf<FloatingNodeRuleViolation>(ex.Rules.Violations.First());
+            Assert.That(ex.Rules.ViolationCount, Is.EqualTo(1));
+            Assert.That(ex.Rules.Violations.First(), Is.InstanceOf<FloatingNodeRuleViolation>());
         }
 
         [Test]
@@ -73,9 +72,9 @@ namespace SpiceSharpTest.Models
                 new VoltageControlledVoltageSource("E2", "0", "out", "in", "0", 2.0));
             var op = new OP("op");
             var ex = Assert.Throws<ValidationFailedException>(() => op.Run(ckt));
-            Assert.AreEqual(1, ex.Rules.ViolationCount);
+            Assert.That(ex.Rules.ViolationCount, Is.EqualTo(1));
             var violation = ex.Rules.Violations.First();
-            Assert.IsInstanceOf<VoltageLoopRuleViolation>(violation);
+            Assert.That(violation, Is.InstanceOf<VoltageLoopRuleViolation>());
         }
 
         [Test]
@@ -88,9 +87,9 @@ namespace SpiceSharpTest.Models
                 new VoltageControlledVoltageSource("E3", "out2", "0", "in", "0", 3.0));
             var op = new OP("op");
             var ex = Assert.Throws<ValidationFailedException>(() => op.Run(ckt));
-            Assert.AreEqual(1, ex.Rules.ViolationCount);
+            Assert.That(ex.Rules.ViolationCount, Is.EqualTo(1));
             var violation = ex.Rules.Violations.First();
-            Assert.IsInstanceOf<VoltageLoopRuleViolation>(violation);
+            Assert.That(violation, Is.InstanceOf<VoltageLoopRuleViolation>());
         }
 
         /*

--- a/SpiceSharpTest/Models/Voltagesources/VCVS/VoltageControlledVoltageSourceTests.cs
+++ b/SpiceSharpTest/Models/Voltagesources/VCVS/VoltageControlledVoltageSourceTests.cs
@@ -6,6 +6,7 @@ using SpiceSharp.Validation;
 using System;
 using System.Linq;
 using System.Numerics;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Models
 {

--- a/SpiceSharpTest/Properties/AssemblyInfo.cs
+++ b/SpiceSharpTest/Properties/AssemblyInfo.cs
@@ -1,19 +1,6 @@
-using System.Reflection;
+﻿using System.Reflection;
 using System.Runtime.InteropServices;
-
-[assembly: AssemblyTitle("SpiceSharpTest")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("SpiceSharpTest")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
 
 [assembly: ComVisible(false)]
 
 [assembly: Guid("de500b6d-352c-4c63-aa37-655d7369d728")]
-
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/SpiceSharpTest/Simulations/ACTests.cs
+++ b/SpiceSharpTest/Simulations/ACTests.cs
@@ -4,7 +4,6 @@ using SpiceSharp.Components;
 using SpiceSharp.Simulations;
 using System.Collections.Generic;
 using System.Numerics;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Simulations
 {
@@ -36,8 +35,8 @@ namespace SpiceSharpTest.Simulations
             int index = 0;
             void CheckReference(object sender, ExportDataEventArgs args)
             {
-                Assert.AreEqual(r[index].Real, export.Value.Real, 1e-20);
-                Assert.AreEqual(r[index++].Imaginary, export.Value.Imaginary, 1e-20);
+                Assert.That(export.Value.Real, Is.EqualTo(r[index].Real).Within(1e-20));
+                Assert.That(export.Value.Imaginary, Is.EqualTo(r[index++].Imaginary).Within(1e-20));
             }
             ac.ExportSimulationData += CheckReference;
             ac.Rerun();

--- a/SpiceSharpTest/Simulations/ACTests.cs
+++ b/SpiceSharpTest/Simulations/ACTests.cs
@@ -2,12 +2,9 @@
 using SpiceSharp;
 using SpiceSharp.Components;
 using SpiceSharp.Simulations;
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Numerics;
-using System.Text;
-using System.Threading.Tasks;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Simulations
 {

--- a/SpiceSharpTest/Simulations/ConcurrentSimulationsTests.cs
+++ b/SpiceSharpTest/Simulations/ConcurrentSimulationsTests.cs
@@ -7,7 +7,6 @@ using SpiceSharpTest.Models;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Simulations
 {
@@ -41,7 +40,7 @@ namespace SpiceSharpTest.Simulations
                     double resistance = Math.Max(dc.GetCurrentSweepValue()[0], SpiceSharp.Components.Resistors.Parameters.MinimumResistance);
                     double voltage = dc.GetCurrentSweepValue()[1];
                     double expected = voltage * resistance / (resistance + 1.0e4);
-                    Assert.AreEqual(expected, args.GetVoltage("out"), 1e-12);
+                    Assert.That(args.GetVoltage("out"), Is.EqualTo(expected).Within(1e-12));
                 };
 
                 dcSimulations.Add(dc);
@@ -72,7 +71,7 @@ namespace SpiceSharpTest.Simulations
                 var tran = new Transient("Tran 1", 1e-6, 10.0);
                 tran.ExportSimulationData += (sender, args) =>
                 {
-                    Assert.AreEqual(args.GetVoltage("out"), 10.0, 1e-12);
+                    Assert.That(args.GetVoltage("out"), Is.EqualTo(10.0).Within(1e-12));
                 };
 
                 transientSimulations.Add(tran);

--- a/SpiceSharpTest/Simulations/ConcurrentSimulationsTests.cs
+++ b/SpiceSharpTest/Simulations/ConcurrentSimulationsTests.cs
@@ -7,6 +7,7 @@ using SpiceSharpTest.Models;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Simulations
 {

--- a/SpiceSharpTest/Simulations/DCTests.cs
+++ b/SpiceSharpTest/Simulations/DCTests.cs
@@ -6,6 +6,7 @@ using SpiceSharp.Simulations;
 using SpiceSharpTest.Models;
 using System;
 using System.Collections.Generic;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Simulations
 {

--- a/SpiceSharpTest/Simulations/DCTests.cs
+++ b/SpiceSharpTest/Simulations/DCTests.cs
@@ -6,7 +6,6 @@ using SpiceSharp.Simulations;
 using SpiceSharpTest.Models;
 using System;
 using System.Collections.Generic;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Simulations
 {
@@ -51,7 +50,7 @@ namespace SpiceSharpTest.Simulations
                 double resistance = Math.Max(dc.GetCurrentSweepValue()[0], SpiceSharp.Components.Resistors.Parameters.MinimumResistance);
                 double voltage = dc.GetCurrentSweepValue()[1];
                 double expected = voltage * resistance / (resistance + 1.0e4);
-                Assert.AreEqual(expected, args.GetVoltage("out"), 1e-12);
+                Assert.That(args.GetVoltage("out"), Is.EqualTo(expected).Within(1e-12));
             };
             dc.Run(ckt);
         }
@@ -120,7 +119,7 @@ namespace SpiceSharpTest.Simulations
 
             // Rerun: check with reference
             int index = 0;
-            void CheckReference(object sender, ExportDataEventArgs args) => Assert.AreEqual(dcExportV1.Value, r[index++], 1e-20);
+            void CheckReference(object sender, ExportDataEventArgs args) => Assert.That(r[index++], Is.EqualTo(dcExportV1.Value).Within(1e-20));
             dc.ExportSimulationData += CheckReference;
             dc.Rerun();
             dc.ExportSimulationData -= CheckReference;
@@ -148,9 +147,9 @@ namespace SpiceSharpTest.Simulations
             dc.ExportSimulationData += (sender, args) =>
             {
                 if (a)
-                    Assert.AreEqual(args.GetVoltage("in") * 0.5, args.GetVoltage("out"), 1e-12);
+                    Assert.That(args.GetVoltage("out"), Is.EqualTo(args.GetVoltage("in") * 0.5).Within(1e-12));
                 else
-                    Assert.AreEqual(args.GetVoltage("in") * 2.0 / 3.0, args.GetVoltage("out"), 1e-12);
+                    Assert.That(args.GetVoltage("out"), Is.EqualTo(args.GetVoltage("in") * 2.0 / 3.0).Within(1e-12));
             };
             a = false; // Doing second circuit
             dc.Run(cktB);

--- a/SpiceSharpTest/Simulations/DecadeSweepTests.cs
+++ b/SpiceSharpTest/Simulations/DecadeSweepTests.cs
@@ -2,6 +2,7 @@
 using SpiceSharp.Simulations;
 using System;
 using System.Linq;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Simulations
 {

--- a/SpiceSharpTest/Simulations/DecadeSweepTests.cs
+++ b/SpiceSharpTest/Simulations/DecadeSweepTests.cs
@@ -2,7 +2,6 @@
 using SpiceSharp.Simulations;
 using System;
 using System.Linq;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Simulations
 {
@@ -22,8 +21,8 @@ namespace SpiceSharpTest.Simulations
             ];
             int index = 0;
             foreach (double c in sweep)
-                Assert.AreEqual(expected[index++], c, 1e-9);
-            Assert.AreEqual(index, expected.Length);
+                Assert.That(c, Is.EqualTo(expected[index++]).Within(1e-9));
+            Assert.That(expected.Length, Is.EqualTo(index));
         }
 
         [Test]
@@ -39,8 +38,8 @@ namespace SpiceSharpTest.Simulations
             ];
             int index = 0;
             foreach (double c in sweep)
-                Assert.AreEqual(expected[index++], c, 1e-9);
-            Assert.AreEqual(index, expected.Length);
+                Assert.That(c, Is.EqualTo(expected[index++]).Within(1e-9));
+            Assert.That(expected.Length, Is.EqualTo(index));
         }
 
         [Test]
@@ -56,8 +55,8 @@ namespace SpiceSharpTest.Simulations
             ];
             int index = 0;
             foreach (double c in sweep)
-                Assert.AreEqual(expected[index++], c, 1e-9);
-            Assert.AreEqual(index, expected.Length);
+                Assert.That(c, Is.EqualTo(expected[index++]).Within(1e-9));
+            Assert.That(expected.Length, Is.EqualTo(index));
         }
 
         [Test]
@@ -73,8 +72,8 @@ namespace SpiceSharpTest.Simulations
             ];
             int index = 0;
             foreach (double c in sweep)
-                Assert.AreEqual(expected[index++], c, 1e-9);
-            Assert.AreEqual(index, expected.Length);
+                Assert.That(c, Is.EqualTo(expected[index++]).Within(1e-9));
+            Assert.That(expected.Length, Is.EqualTo(index));
         }
 
         [Test]

--- a/SpiceSharpTest/Simulations/NoiseTests.cs
+++ b/SpiceSharpTest/Simulations/NoiseTests.cs
@@ -3,6 +3,7 @@ using SpiceSharp;
 using SpiceSharp.Components;
 using SpiceSharp.Simulations;
 using System.Collections.Generic;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Simulations
 {

--- a/SpiceSharpTest/Simulations/NoiseTests.cs
+++ b/SpiceSharpTest/Simulations/NoiseTests.cs
@@ -3,7 +3,6 @@ using SpiceSharp;
 using SpiceSharp.Components;
 using SpiceSharp.Simulations;
 using System.Collections.Generic;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Simulations
 {
@@ -35,7 +34,7 @@ namespace SpiceSharpTest.Simulations
             int index = 0;
             void CheckReference(object sender, ExportDataEventArgs args)
             {
-                Assert.AreEqual(r[index++], export.Value, 1e-20);
+                Assert.That(export.Value, Is.EqualTo(r[index++]).Within(1e-20));
             }
             noise.ExportSimulationData += CheckReference;
             noise.Rerun();

--- a/SpiceSharpTest/Simulations/OctaveSweepTests.cs
+++ b/SpiceSharpTest/Simulations/OctaveSweepTests.cs
@@ -2,7 +2,6 @@
 using SpiceSharp.Simulations;
 using System;
 using System.Linq;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Simulations
 {
@@ -29,8 +28,8 @@ namespace SpiceSharpTest.Simulations
             ];
             int index = 0;
             foreach (double c in sweep)
-                Assert.AreEqual(expected[index++], c, 1e-9);
-            Assert.AreEqual(index, expected.Length);
+                Assert.That(c, Is.EqualTo(expected[index++]).Within(1e-9));
+            Assert.That(expected.Length, Is.EqualTo(index));
         }
 
         [Test]
@@ -53,8 +52,8 @@ namespace SpiceSharpTest.Simulations
             ];
             int index = 0;
             foreach (double c in sweep)
-                Assert.AreEqual(expected[index++], c, 1e-9);
-            Assert.AreEqual(index, expected.Length);
+                Assert.That(c, Is.EqualTo(expected[index++]).Within(1e-9));
+            Assert.That(expected.Length, Is.EqualTo(index));
         }
 
         [Test]
@@ -77,8 +76,8 @@ namespace SpiceSharpTest.Simulations
             ];
             int index = 0;
             foreach (double c in sweep)
-                Assert.AreEqual(expected[index++], c, 1e-9);
-            Assert.AreEqual(index, expected.Length);
+                Assert.That(c, Is.EqualTo(expected[index++]).Within(1e-9));
+            Assert.That(expected.Length, Is.EqualTo(index));
         }
 
         [Test]
@@ -101,8 +100,8 @@ namespace SpiceSharpTest.Simulations
             ];
             int index = 0;
             foreach (double c in sweep)
-                Assert.AreEqual(expected[index++], c, 1e-9);
-            Assert.AreEqual(index, expected.Length);
+                Assert.That(c, Is.EqualTo(expected[index++]).Within(1e-9));
+            Assert.That(expected.Length, Is.EqualTo(index));
         }
 
         [Test]

--- a/SpiceSharpTest/Simulations/OctaveSweepTests.cs
+++ b/SpiceSharpTest/Simulations/OctaveSweepTests.cs
@@ -2,6 +2,7 @@
 using SpiceSharp.Simulations;
 using System;
 using System.Linq;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Simulations
 {

--- a/SpiceSharpTest/Simulations/TransientTests.cs
+++ b/SpiceSharpTest/Simulations/TransientTests.cs
@@ -6,6 +6,7 @@ using SpiceSharp.Simulations.IntegrationMethods;
 using SpiceSharpTest.Models;
 using System;
 using System.Collections.Generic;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Simulations
 {

--- a/SpiceSharpTest/Simulations/TransientTests.cs
+++ b/SpiceSharpTest/Simulations/TransientTests.cs
@@ -6,7 +6,6 @@ using SpiceSharp.Simulations.IntegrationMethods;
 using SpiceSharpTest.Models;
 using System;
 using System.Collections.Generic;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Simulations
 {
@@ -27,7 +26,7 @@ namespace SpiceSharpTest.Simulations
             var tran = new Transient("tran 1", 1.0, 10.0);
             tran.ExportSimulationData += (sender, args) =>
             {
-                Assert.AreEqual(10.0, args.GetVoltage("out"), 1e-12);
+                Assert.That(args.GetVoltage("out"), Is.EqualTo(10.0).Within(1e-12));
             };
             tran.Run(ckt);
 
@@ -55,7 +54,7 @@ namespace SpiceSharpTest.Simulations
             var tran = new Transient("tran 1", new Gear { InitialStep = 1, StopTime = 10 });
             tran.ExportSimulationData += (sender, args) =>
             {
-                Assert.AreEqual(10.0, args.GetVoltage("out"), 1e-10);
+                Assert.That(args.GetVoltage("out"), Is.EqualTo(10.0).Within(1e-10));
             };
             tran.Run(ckt);
 
@@ -83,7 +82,7 @@ namespace SpiceSharpTest.Simulations
             var tran = new Transient("Tran 1", 1e-6, 10.0);
             tran.ExportSimulationData += (sender, args) =>
             {
-                Assert.AreEqual(args.GetVoltage("out"), 10.0, 1e-12);
+                Assert.That(args.GetVoltage("out"), Is.EqualTo(10.0).Within(1e-12));
             };
             tran.Run(ckt);
         }
@@ -105,7 +104,7 @@ namespace SpiceSharpTest.Simulations
                 if (args.Time > 5.0)
                 {
                     export ??= new RealPropertyExport((Simulation)sender, "R1", "i");
-                    Assert.AreEqual(10.0 / 1e3, export.Value, 1e-12);
+                    Assert.That(export.Value, Is.EqualTo(10.0 / 1e3).Within(1e-12));
                 }
             };
             tran.Run(ckt);
@@ -445,17 +444,17 @@ namespace SpiceSharpTest.Simulations
             sim1.ExportSimulationData += (sender, e) =>
             {
                 double input = e.GetVoltage("in");
-                Assert.AreEqual(input * 0.5, vexport.Value, 1e-9);
-                Assert.AreEqual(-input / 2.0e3, iexport.Value, 1e-9);
-                Assert.AreEqual(input * input / 4.0 / 1.0e3, pexport.Value, 1e-9);
+                Assert.That(vexport.Value, Is.EqualTo(input * 0.5).Within(1e-9));
+                Assert.That(iexport.Value, Is.EqualTo(-input / 2.0e3).Within(1e-9));
+                Assert.That(pexport.Value, Is.EqualTo(input * input / 4.0 / 1.0e3).Within(1e-9));
             };
             sim2.ExportSimulationData += (sender, e) =>
             {
                 double input = e.GetVoltage("in");
-                Assert.AreEqual(Math.Sin(2 * Math.PI * 10 * e.Time) + 1.0, input, 1e-9);
-                Assert.AreEqual(input * 0.5, vexport.Value, 1e-9);
-                Assert.AreEqual(-input / 2.0e3, iexport.Value, 1e-9);
-                Assert.AreEqual(input * input / 4.0 / 1.0e3, pexport.Value, 1e-9);
+                Assert.That(input, Is.EqualTo(Math.Sin(2 * Math.PI * 10 * e.Time) + 1.0).Within(1e-9));
+                Assert.That(vexport.Value, Is.EqualTo(input * 0.5).Within(1e-9));
+                Assert.That(iexport.Value, Is.EqualTo(-input / 2.0e3).Within(1e-9));
+                Assert.That(pexport.Value, Is.EqualTo(input * input / 4.0 / 1.0e3).Within(1e-9));
             };
             sim1.Run(ckt);
 
@@ -490,9 +489,9 @@ namespace SpiceSharpTest.Simulations
             tran.ExportSimulationData += (sender, args) =>
             {
                 if (a)
-                    Assert.AreEqual(args.Time * 1e-3 / 1e-6, args.GetVoltage("in"), 1e-12);
+                    Assert.That(args.GetVoltage("in"), Is.EqualTo(args.Time * 1e-3 / 1e-6).Within(1e-12));
                 else
-                    Assert.AreEqual(args.Time * 1e-3 / 2e-6, args.GetVoltage("in"), 1e-12);
+                    Assert.That(args.GetVoltage("in"), Is.EqualTo(args.Time * 1e-3 / 2e-6).Within(1e-12));
             };
             a = false; // Doing second circuit
             tran.Run(cktB);
@@ -524,7 +523,7 @@ namespace SpiceSharpTest.Simulations
 
             // Rerun the simulation for building the reference values
             int index = 0;
-            void CheckReference(object sender, ExportDataEventArgs args) => Assert.AreEqual(r[index++], export.Value, 1e-20);
+            void CheckReference(object sender, ExportDataEventArgs args) => Assert.That(export.Value, Is.EqualTo(r[index++]).Within(1e-20));
             tran.ExportSimulationData += CheckReference;
             tran.Rerun();
             tran.ExportSimulationData -= CheckReference;

--- a/SpiceSharpTest/SpiceSharpTest.csproj
+++ b/SpiceSharpTest/SpiceSharpTest.csproj
@@ -1,126 +1,16 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{DE500B6D-352C-4C63-AA37-655D7369D728}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>SpiceSharpTest</RootNamespace>
-    <AssemblyName>SpiceSharpTest</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <TargetFramework>net8.0</TargetFramework>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
-    <TargetFrameworkProfile />
+    <Product>SpiceSharpTest</Product>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet />
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet />
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
-  <PropertyGroup>
-    <RuntimeIdentifiers>win;osx;linux</RuntimeIdentifiers>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Numerics" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Algebra\DenseFactorTests.cs" />
-    <Compile Include="Algebra\DenseMatrixTests.cs" />
-    <Compile Include="Algebra\DenseSolverTests.cs" />
-    <Compile Include="Algebra\DenseVectorTests.cs" />
-    <Compile Include="BasicExampleTests.cs" />
-    <Compile Include="Circuits\CircuitTests.cs" />
-    <Compile Include="Examples\ChangingParameter\Changing.cs" />
-    <Compile Include="Examples\CustomResistor\BaseParameters.cs" />
-    <Compile Include="Examples\CustomResistor\NonlinearResistor.cs" />
-    <Compile Include="Examples\CustomResistor\BiasingBehavior.cs" />
-    <Compile Include="Examples\CustomResistor\NonlinearResistorTests.cs" />
-    <Compile Include="Examples\SimpleDiode\DiodeBiasing.cs" />
-    <Compile Include="Examples\SimpleDiode\DiodeParameters.cs" />
-    <Compile Include="Examples\SimpleDiode\DiodeTemperature.cs" />
-    <Compile Include="General\GeneratorTests.cs" />
-    <Compile Include="General\InheritedTypeDictionaryTests.cs" />
-    <Compile Include="Helper.cs" />
-    <Compile Include="Models\ComponentHelper.cs" />
-    <Compile Include="Models\ComponentRules.cs" />
-    <Compile Include="Models\Currentsources\CCCS\CurrentControlledCurrentSourceTests.cs" />
-    <Compile Include="Models\Currentsources\ISRC\CurrentSourceTests.cs" />
-    <Compile Include="Models\Currentsources\VCCS\VoltageControlledCurrentSourceTests.cs" />
-    <Compile Include="Models\Distributed\DelayTests.cs" />
-    <Compile Include="Models\Distributed\TransmissionLineTests.cs" />
-    <Compile Include="Models\BindingContextHelper.cs" />
-    <Compile Include="Models\Parallel\SimpleParallelTests.cs" />
-    <Compile Include="Models\Proxy.cs" />
-    <Compile Include="Models\RLC\CAP\CapacitorTests.cs" />
-    <Compile Include="Models\RLC\IND\InductorTests.cs" />
-    <Compile Include="Models\RLC\MUT\MutualInductanceTests.cs" />
-    <Compile Include="Models\RLC\RES\ResistorTests.cs" />
-    <Compile Include="Models\Framework.cs" />
-    <Compile Include="Models\Sampler\SamplerTests.cs" />
-    <Compile Include="Models\Semiconductors\Bipolar\BipolarJunctionTransistorTests.cs" />
-    <Compile Include="Models\Semiconductors\DIO\DiodeTests.cs" />
-    <Compile Include="Models\Semiconductors\JFET\JFETTests.cs" />
-    <Compile Include="Models\Semiconductors\Mosfet\Level1\MOS1Tests.cs" />
-    <Compile Include="Models\Semiconductors\Mosfet\Level2\MOS2Tests.cs" />
-    <Compile Include="Algebra\SparseMatrixTests.cs" />
-    <Compile Include="Algebra\SparseSolverTests.cs" />
-    <Compile Include="Algebra\SparseVectorTests.cs" />
-    <Compile Include="Algebra\SolveFramework.cs" />
-    <Compile Include="Models\Semiconductors\Mosfet\Level3\MOS3Tests.cs" />
-    <Compile Include="Models\Subcircuits\SubcircuitLocalSolverTests.cs" />
-    <Compile Include="Models\Subcircuits\SimpleSubcircuitTests.cs" />
-    <Compile Include="Models\Switches\CSW\CurrentSwitchTests.cs" />
-    <Compile Include="Models\Switches\VSW\VoltageSwitchTests.cs" />
-    <Compile Include="Models\Voltagesources\CCVS\CurrentControlledVoltageSourceTests.cs" />
-    <Compile Include="Models\Voltagesources\VCVS\VoltageControlledVoltageSourceTests.cs" />
-    <Compile Include="Models\Voltagesources\VSRC\VoltageSourceTests.cs" />
-    <Compile Include="ParameterTests.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Algebra\SparseFactorTests.cs" />
-    <Compile Include="Simulations\ACTests.cs" />
-    <Compile Include="Simulations\ConcurrentSimulationsTests.cs" />
-    <Compile Include="Simulations\DCTests.cs" />
-    <Compile Include="Simulations\DecadeSweepTests.cs" />
-    <Compile Include="Simulations\DerivativeTester.cs" />
-    <Compile Include="Simulations\IntegralTester.cs" />
-    <Compile Include="Simulations\NoiseTests.cs" />
-    <Compile Include="Simulations\OctaveSweepTests.cs" />
-    <Compile Include="Simulations\TransientTests.cs" />
-    <Compile Include="Models\WaveformTests.cs" />
-    <Compile Include="Waveforms\AMTests.cs" />
-    <Compile Include="Waveforms\PulseTests.cs" />
-    <Compile Include="Waveforms\PwlTests.cs" />
-    <Compile Include="Waveforms\SFFMTests.cs" />
-    <Compile Include="Waveforms\SineTests.cs" />
-  </ItemGroup>
+
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+
   <ItemGroup>
     <Content Include="Algebra\Matrices\spice3f5_matrix01.dat">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -132,30 +22,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+
   <ItemGroup>
-    <ProjectReference Include="..\SpiceSharp\SpiceSharp.csproj">
-      <Project>{fd906b56-e076-46b7-acef-2d870189588c}</Project>
-      <Name>SpiceSharp</Name>
-    </ProjectReference>
+    <ProjectReference Include="$(RepoRoot)SpiceSharp/SpiceSharp.csproj" />
+    <ProjectReference Include="$(RepoRoot)SpiceSharpGenerator/SpiceSharpGenerator.csproj" />
+    <ProjectReference Include="$(RepoRoot)SpiceSharpGenerator/SpiceSharpGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="NUnit">
-      <Version>3.13.2</Version>
-    </PackageReference>
-    <PackageReference Include="NUnit.Console">
-      <Version>3.12.0</Version>
-    </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter">
-      <Version>3.17.0</Version>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <ItemGroup>
-    <ProjectReference Include="../SpiceSharpGenerator/SpiceSharpGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false">
-      <SetConfiguration>Configuration=Release</SetConfiguration>
-    </ProjectReference>
-  </ItemGroup>
+
 </Project>

--- a/SpiceSharpTest/SpiceSharpTest.csproj
+++ b/SpiceSharpTest/SpiceSharpTest.csproj
@@ -2,14 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
-    <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
-    <Product>SpiceSharpTest</Product>
   </PropertyGroup>
-
-  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
 
   <ItemGroup>
     <Content Include="Algebra\Matrices\spice3f5_matrix01.dat">
@@ -25,7 +19,6 @@
 
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)SpiceSharp/SpiceSharp.csproj" />
-    <ProjectReference Include="$(RepoRoot)SpiceSharpGenerator/SpiceSharpGenerator.csproj" />
     <ProjectReference Include="$(RepoRoot)SpiceSharpGenerator/SpiceSharpGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 

--- a/SpiceSharpTest/Waveforms/AMTests.cs
+++ b/SpiceSharpTest/Waveforms/AMTests.cs
@@ -3,10 +3,7 @@ using SpiceSharp;
 using SpiceSharp.Components;
 using SpiceSharp.Simulations;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Waveforms
 {

--- a/SpiceSharpTest/Waveforms/AMTests.cs
+++ b/SpiceSharpTest/Waveforms/AMTests.cs
@@ -3,7 +3,6 @@ using SpiceSharp;
 using SpiceSharp.Components;
 using SpiceSharp.Simulations;
 using System;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Waveforms
 {
@@ -34,13 +33,12 @@ namespace SpiceSharpTest.Waveforms
             {
                 double time = args.Time - td;
                 if (time <= 0)
-                    Assert.AreEqual(0.0, args.GetVoltage("a"), 1e-12);
+                    Assert.That(args.GetVoltage("a"), Is.EqualTo(0.0).Within(1e-12));
                 else
                 {
-                    Assert.AreEqual(
-                        va * (vo + Math.Sin(2.0 * Math.PI * mf * time + phases * Math.PI / 180.0)) *
-                        Math.Sin(2.0 * Math.PI * fc * time + phasec * Math.PI / 180.0),
-                        args.GetVoltage("a"), 1e-12);
+                    Assert.That(
+                        args.GetVoltage("a"), Is.EqualTo(va * (vo + Math.Sin(2.0 * Math.PI * mf * time + phases * Math.PI / 180.0)) *
+                        Math.Sin(2.0 * Math.PI * fc * time + phasec * Math.PI / 180.0)).Within(1e-12));
                 }
             };
             tran.Run(ckt);

--- a/SpiceSharpTest/Waveforms/PulseTests.cs
+++ b/SpiceSharpTest/Waveforms/PulseTests.cs
@@ -66,10 +66,10 @@ namespace SpiceSharpTest.Waveforms
             };
             tran.Run(ckt);
 
-            Assert.True(riseHit);
-            Assert.True(risenHit);
-            Assert.True(fallHit);
-            Assert.True(fallenHit);
+            Assert.That(riseHit);
+            Assert.That(risenHit);
+            Assert.That(fallHit);
+            Assert.That(fallenHit);
         }
     }
 }

--- a/SpiceSharpTest/Waveforms/PwlTests.cs
+++ b/SpiceSharpTest/Waveforms/PwlTests.cs
@@ -4,7 +4,6 @@ using SpiceSharp.Components;
 using SpiceSharp.Simulations;
 using SpiceSharpTest.Models;
 using System;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Waveforms
 {
@@ -42,7 +41,7 @@ namespace SpiceSharpTest.Waveforms
             var tran = new Transient("Tran 1", 1e-6, 10.0);
             tran.ExportSimulationData += (sender, args) =>
             {
-                Assert.AreEqual(2.0, args.GetVoltage("in"), 1e-12);
+                Assert.That(args.GetVoltage("in"), Is.EqualTo(2.0).Within(1e-12));
             };
             tran.Run(ckt);
         }
@@ -60,7 +59,7 @@ namespace SpiceSharpTest.Waveforms
             var tran = new Transient("Tran 1", 1e-6, 1.0);
             tran.ExportSimulationData += (sender, args) =>
             {
-                Assert.AreEqual(args.Time < 1.0 ? 2.0 * args.Time : 2.0, args.GetVoltage("in"), 1e-12);
+                Assert.That(args.GetVoltage("in"), Is.EqualTo(args.Time < 1.0 ? 2.0 * args.Time : 2.0).Within(1e-12));
             };
             tran.Run(ckt);
         }
@@ -78,7 +77,7 @@ namespace SpiceSharpTest.Waveforms
             var tran = new Transient("Tran 1", 1e-6, 1.0);
             tran.ExportSimulationData += (sender, args) =>
             {
-                Assert.AreEqual(args.Time < 1.0 ? 1.0 + args.Time : 2.0, args.GetVoltage("in"), 1e-12);
+                Assert.That(args.GetVoltage("in"), Is.EqualTo(args.Time < 1.0 ? 1.0 + args.Time : 2.0).Within(1e-12));
             };
             tran.Run(ckt);
         }
@@ -102,7 +101,7 @@ namespace SpiceSharpTest.Waveforms
             var tran = new Transient("Tran 1", 1e-2, n - 1);
             tran.ExportSimulationData += (sender, args) =>
             {
-                Assert.AreEqual(args.Time, args.GetVoltage("in"), 1e-12);
+                Assert.That(args.GetVoltage("in"), Is.EqualTo(args.Time).Within(1e-12));
             };
             tran.Run(ckt);
         }
@@ -130,17 +129,17 @@ namespace SpiceSharpTest.Waveforms
 
                 if (args.Time == integer)
                 {
-                    Assert.AreEqual(integer % 2, args.GetVoltage("in"), 1e-12);
+                    Assert.That(args.GetVoltage("in"), Is.EqualTo(integer % 2).Within(1e-12));
                 }
                 else
                 {
                     if (integer % 2 == 0)
                     {
-                        Assert.AreEqual(args.Time - integer, args.GetVoltage("in"), 1e-12);
+                        Assert.That(args.GetVoltage("in"), Is.EqualTo(args.Time - integer).Within(1e-12));
                     }
                     else
                     {
-                        Assert.AreEqual(1 - (args.Time - integer), args.GetVoltage("in"), 1e-12);
+                        Assert.That(args.GetVoltage("in"), Is.EqualTo(1 - (args.Time - integer)).Within(1e-12));
                     }
                 }
             };
@@ -173,12 +172,12 @@ namespace SpiceSharpTest.Waveforms
                     wasHit2 = true;
                 }
 
-                Assert.AreEqual(2.0, args.GetVoltage("in"), 1e-12);
+                Assert.That(args.GetVoltage("in"), Is.EqualTo(2.0).Within(1e-12));
             };
             tran.Run(ckt);
 
-            Assert.True(wasHit1);
-            Assert.True(wasHit2);
+            Assert.That(wasHit1);
+            Assert.That(wasHit2);
         }
     }
 }

--- a/SpiceSharpTest/Waveforms/PwlTests.cs
+++ b/SpiceSharpTest/Waveforms/PwlTests.cs
@@ -4,6 +4,7 @@ using SpiceSharp.Components;
 using SpiceSharp.Simulations;
 using SpiceSharpTest.Models;
 using System;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Waveforms
 {

--- a/SpiceSharpTest/Waveforms/SFFMTests.cs
+++ b/SpiceSharpTest/Waveforms/SFFMTests.cs
@@ -3,6 +3,7 @@ using SpiceSharp;
 using SpiceSharp.Components;
 using SpiceSharp.Simulations;
 using System;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Waveforms
 {

--- a/SpiceSharpTest/Waveforms/SFFMTests.cs
+++ b/SpiceSharpTest/Waveforms/SFFMTests.cs
@@ -3,7 +3,6 @@ using SpiceSharp;
 using SpiceSharp.Components;
 using SpiceSharp.Simulations;
 using System;
-using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
 namespace SpiceSharpTest.Waveforms
 {
@@ -33,9 +32,8 @@ namespace SpiceSharpTest.Waveforms
             tran.ExportSimulationData += (sender, args) =>
             {
                 double time = args.Time;
-                Assert.AreEqual(vo + va * Math.Sin(2.0 * Math.PI * fc * time + phasec * Math.PI / 180.0 +
-                    mdi * Math.Sin(2.0 * Math.PI * fs * time + phases * Math.PI / 180.0)),
-                    args.GetVoltage("a"), 1e-12);
+                Assert.That(args.GetVoltage("a"), Is.EqualTo(vo + va * Math.Sin(2.0 * Math.PI * fc * time + phasec * Math.PI / 180.0 +
+                    mdi * Math.Sin(2.0 * Math.PI * fs * time + phases * Math.PI / 180.0))).Within(1e-12));
             };
             tran.Run(ckt);
         }

--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,0 +1,4 @@
+## Build artifacts will end up in this directory
+## hence, everything can be ignored
+
+*


### PR DESCRIPTION
I saw that there were quite some shared properties in the `csproj` files, and moved those to the `Directory.Build.prop` and `-.target` files. Furthermore some NuGet packages were outdated, so I updated all of them ~~(meaning that the `NUnit` now need to use the legacy assertions, I can update all the assertions to the `Assert.That` in a follow up PR)~~.

I also updated the test project from .NET Framework 4.7.2 to .NET 8. But I can revert that if there is a good reason to stay on framework.

I don't know what the `<Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />` does in the `SpiceSharp` Project. Can that be removed?