### PR TITLE
Added GitInfo to automate versioning

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,8 +22,6 @@
   
   <!-- Assembly info -->
   <PropertyGroup>
-    <Version>3.1.9</Version>
-	<AssemblyVersion>3.1.9.0</AssemblyVersion>
     <Authors>Sven Boulanger</Authors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Title>Spice#</Title>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -21,10 +21,22 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-  
+
   <!-- Disable some rules for test projects -->
   <PropertyGroup Condition="'$(TestProjectType)' != ''">
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
-  
+
+  <!-- Automatic versioning using GitInfo if UseGitInfo is set to true -->
+  <PropertyGroup Condition="'$(UseGitInfo)' == 'true'">
+    <GitSkipCache>true</GitSkipCache>
+    <GitBaseVersionRegex>^(?:\w+-)?v?(?&lt;MAJOR&gt;\d+)\.(?&lt;MINOR&gt;\d+)\.(?&lt;PATCH&gt;\d+)$</GitBaseVersionRegex>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(UseGitInfo)' == 'true'">
+    <PackageReference Include="GitInfo" Version="3.3.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/SpiceSharp/SpiceSharp.csproj
+++ b/SpiceSharp/SpiceSharp.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <Description>Spice# is a circuit simulator based on and improved from Spice 3f5 by Berkeley. The framework allows custom components and simulations to be added.</Description>
+    <UseGitInfo>true</UseGitInfo>
+		<GitTagRegex>v*</GitTagRegex>
   </PropertyGroup>
 
 	<ItemGroup>

--- a/SpiceSharpGenerator/SpiceSharpGenerator.csproj
+++ b/SpiceSharpGenerator/SpiceSharpGenerator.csproj
@@ -6,9 +6,9 @@
 		<SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
 		<Description>A source generator that is built to help extending the functionality of the SpiceSharp framework.</Description>
-		<Version>1.0.5</Version>
-		<AssemblyVersion>1.0.5.0</AssemblyVersion>
     <NoWarn>$(NoWarn);RS1035</NoWarn>
+    <UseGitInfo>true</UseGitInfo>
+    <GitTagRegex>generator-v*</GitTagRegex>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
As mentioned in my previous PR, you can do automatic versioning using GitInfo. I added that in this PR.

I mentioned that I did not know if it was possible to use different versions for SpiceSharp and for SpiceSharpGenerator, but it is. Using the `<GitTagRegex>` it is possible to make a distinction. Therefore I set it to `v*` for SpiceSharp, and to `generator-v*` for the generator. The last time the generator has been updated in the master branch is commit  `bbcce26d0c60d7902b5561cac5406cdbb6eff514`, so you'd have to add a tag `generator-v1.0.5` to that commit to get this working. 