### PR TITLE
Various fixes

### DIFF
--- a/SpiceSharp/Algebra/Matrix/DenseMatrix/DenseMatrix.cs
+++ b/SpiceSharp/Algebra/Matrix/DenseMatrix/DenseMatrix.cs
@@ -138,8 +138,12 @@ namespace SpiceSharp.Algebra
                 _trashCan = value;
             else
             {
-                if (!EqualityComparer<T>.Default.Equals(value, default) && (location.Row > Size || location.Column > Size))
+                if (location.Row > Size || location.Column > Size)
+                {
+                    if (EqualityComparer<T>.Default.Equals(value, default))
+                        return;
                     Expand(Math.Max(location.Row, location.Column));
+                }
                 _array[(location.Row - 1) * _allocatedSize + location.Column - 1] = value;
             }
         }

--- a/SpiceSharp/Algebra/Vector/DenseVector/DenseVector.cs
+++ b/SpiceSharp/Algebra/Vector/DenseVector/DenseVector.cs
@@ -59,7 +59,7 @@ namespace SpiceSharp.Algebra
         /// <param name="length">The length of the vector.</param>
         public DenseVector(int length)
         {
-            if (length < 0 && length > int.MaxValue - 1)
+            if (length < 0 || length > int.MaxValue - 1)
                 throw new ArgumentOutOfRangeException(nameof(length));
             Length = length;
             _values = new T[length + 1];

--- a/SpiceSharp/Components/Currentsources/CCCS/Biasing.cs
+++ b/SpiceSharp/Components/Currentsources/CCCS/Biasing.cs
@@ -31,7 +31,7 @@ namespace SpiceSharp.Components.CurrentControlledCurrentSources
 
         /// <include file='./Components/Common/docs.xml' path='docs/members[@name="biasing"]/Current/*'/>
         [ParameterName("i"), ParameterName("c"), ParameterName("i_r"), ParameterInfo("Current")]
-        public double Current => _control.Value * Parameters.Coefficient;
+        public double Current => _control.Value * Parameters.Coefficient * Parameters.ParallelMultiplier;
 
         /// <include file='./Components/Common/docs.xml' path='docs/members[@name="biasing"]/Voltage/*'/>
         [ParameterName("v"), ParameterName("v_r"), ParameterInfo("Voltage")]

--- a/SpiceSharp/Components/Currentsources/CCCS/Frequency.cs
+++ b/SpiceSharp/Components/Currentsources/CCCS/Frequency.cs
@@ -29,7 +29,7 @@ namespace SpiceSharp.Components.CurrentControlledCurrentSources
 
         /// <include file='./Components/Common/docs.xml' path='docs/members[@name="frequency"]/Current/*'/>
         [ParameterName("i"), ParameterName("c"), ParameterName("i_c"), ParameterInfo("Complex current")]
-        public Complex ComplexCurrent => _control.Value * Parameters.Coefficient;
+        public Complex ComplexCurrent => _control.Value * Parameters.Coefficient * Parameters.ParallelMultiplier;
 
         /// <include file='./Components/Common/docs.xml' path='docs/members[@name="frequency"]/Power/*'/>
         [ParameterName("p"), ParameterName("p_c"), ParameterInfo("Complex power")]

--- a/SpiceSharp/Components/Currentsources/ISRC/Frequency.cs
+++ b/SpiceSharp/Components/Currentsources/ISRC/Frequency.cs
@@ -28,11 +28,11 @@ namespace SpiceSharp.Components.CurrentSources
 
         /// <include file='./Components/Common/docs.xml' path='docs/members[@name="frequency"]/Power/*'/>
         [ParameterName("p"), ParameterName("p_c"), ParameterInfo("Complex power")]
-        public Complex ComplexPower => -ComplexVoltage * Complex.Conjugate(Parameters.Phasor);
+        public Complex ComplexPower => -ComplexVoltage * Complex.Conjugate(ComplexCurrent);
 
         /// <include file='./Components/Common/docs.xml' path='docs/members[@name="frequency"]/Current/*'/>
         [ParameterName("i"), ParameterName("c"), ParameterName("i_c"), ParameterInfo("Complex current")]
-        public Complex ComplexCurrent => Parameters.Phasor;
+        public Complex ComplexCurrent => Parameters.Phasor * Parameters.ParallelMultiplier;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Frequency"/> class.

--- a/SpiceSharp/Components/Currentsources/VCCS/Biasing.cs
+++ b/SpiceSharp/Components/Currentsources/VCCS/Biasing.cs
@@ -34,7 +34,7 @@ namespace SpiceSharp.Components.VoltageControlledCurrentSources
 
         /// <include file='./Components/Common/docs.xml' path='docs/members[@name="biasing"]/Current/*'/>
         [ParameterName("i"), ParameterName("c"), ParameterName("i_r"), ParameterInfo("Current")]
-        public double Current => (_variables.Left.Positive.Value - _variables.Left.Negative.Value) * Parameters.Transconductance;
+        public double Current => (_variables.Left.Positive.Value - _variables.Left.Negative.Value) * Parameters.Transconductance * Parameters.ParallelMultiplier;
 
         /// <include file='./Components/Common/docs.xml' path='docs/members[@name="biasing"]/Power/*'/>
         [ParameterName("p"), ParameterName("p_r"), ParameterInfo("Power")]

--- a/SpiceSharp/Components/Currentsources/VCCS/Frequency.cs
+++ b/SpiceSharp/Components/Currentsources/VCCS/Frequency.cs
@@ -28,7 +28,7 @@ namespace SpiceSharp.Components.VoltageControlledCurrentSources
 
         /// <include file='./Components/Common/docs.xml' path='docs/members[@name="frequency"]/Current/*'/>
         [ParameterName("i"), ParameterName("c"), ParameterName("i_c"), ParameterInfo("Complex current")]
-        public Complex ComplexCurrent => (_variables.Left.Positive.Value - _variables.Left.Negative.Value) * Parameters.Transconductance;
+        public Complex ComplexCurrent => (_variables.Left.Positive.Value - _variables.Left.Negative.Value) * Parameters.Transconductance * Parameters.ParallelMultiplier;
 
         /// <include file='./Components/Common/docs.xml' path='docs/members[@name="frequency"]/Power/*'/>
         [ParameterName("p"), ParameterName("p_c"), ParameterInfo("Power")]

--- a/SpiceSharp/Components/Distributed/LoslessTransmissionLines/Biasing.cs
+++ b/SpiceSharp/Components/Distributed/LoslessTransmissionLines/Biasing.cs
@@ -125,7 +125,7 @@ namespace SpiceSharp.Components.LosslessTransmissionLines
         /// The power on side 2.
         /// </value>
         [ParameterName("p2"), ParameterName("p2_r"), ParameterInfo("Power 2")]
-        public double Power2 => -Voltage1 * Current1;
+        public double Power2 => -Voltage2 * Current2;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Biasing"/> class.

--- a/SpiceSharp/Components/Distributed/LoslessTransmissionLines/Frequency.cs
+++ b/SpiceSharp/Components/Distributed/LoslessTransmissionLines/Frequency.cs
@@ -96,7 +96,7 @@ namespace SpiceSharp.Components.LosslessTransmissionLines
         /// The power on side 1.
         /// </value>
         [ParameterName("p1"), ParameterName("p1_r"), ParameterInfo("Power 1")]
-        public Complex ComplexPower1 => -Voltage1 * Current1;
+        public Complex ComplexPower1 => -ComplexVoltage1 * Complex.Conjugate(ComplexCurrent1);
 
         /// <summary>
         /// Gets the power on side 2.
@@ -105,7 +105,7 @@ namespace SpiceSharp.Components.LosslessTransmissionLines
         /// The power on side 2.
         /// </value>
         [ParameterName("p2"), ParameterName("p2_r"), ParameterInfo("Power 2")]
-        public Complex ComplexPower2 => -Voltage1 * Current1;
+        public Complex ComplexPower2 => -ComplexVoltage2 * Complex.Conjugate(ComplexCurrent2);
 
 
         /// <summary>

--- a/SpiceSharp/Components/RLC/Inductors/Frequency.cs
+++ b/SpiceSharp/Components/RLC/Inductors/Frequency.cs
@@ -34,7 +34,7 @@ namespace SpiceSharp.Components.Inductors
 
         /// <include file='./Components/Common/docs.xml' path='docs/members[@name="frequency"]/Power/*'/>
         [ParameterName("p"), ParameterInfo("The complex power")]
-        public Complex ComplexPower => -Branch.Value * (_variables.Positive.Value - _variables.Negative.Value);
+        public Complex ComplexPower => -ComplexVoltage * Complex.Conjugate(ComplexCurrent);
 
         /// <inheritdoc/>
         public new IVariable<Complex> Branch { get; }

--- a/SpiceSharp/Components/Semiconductors/Mosfets/Common/Time.cs
+++ b/SpiceSharp/Components/Semiconductors/Mosfets/Common/Time.cs
@@ -115,7 +115,7 @@ namespace SpiceSharp.Components.Mosfets
             double GateBulkOverlapCap = _mp.GateBulkOverlapCapFactor * _behavior.Parameters.ParallelMultiplier * _behavior.Properties.EffectiveLength;
 
             double capgs = 2 * _charges.Cgs + GateSourceOverlapCap;
-            double capgd = 2 * _charges.Cgs + GateDrainOverlapCap;
+            double capgd = 2 * _charges.Cgd + GateDrainOverlapCap;
             double capgb = 2 * _charges.Cgb + GateBulkOverlapCap;
 
             _qgs.Value = capgs * vgs;
@@ -172,7 +172,7 @@ namespace SpiceSharp.Components.Mosfets
             _vbs.Value = vbs;
             _qgs.Value = (vgs - vgs1) * capgs + _qgs.GetPreviousValue(1);
             _qgd.Value = (vgd - vgd1) * capgd + _qgd.GetPreviousValue(1);
-            _qgb.Value = (vgb1 - vgb1) * capgb + _qgb.GetPreviousValue(1);
+            _qgb.Value = (vgb - vgb1) * capgb + _qgb.GetPreviousValue(1);
 
             _qgs.Derive();
             var info = _qgs.GetContributions(capgs, vgs);

--- a/SpiceSharp/Components/Semiconductors/Mosfets/Level2/Temperature.cs
+++ b/SpiceSharp/Components/Semiconductors/Mosfets/Level2/Temperature.cs
@@ -163,8 +163,8 @@ namespace SpiceSharp.Components.Mosfets.Level2
             double gmanew = (Properties.TempBulkPotential - pbo) / pbo;
             capfact = (1 + ModelParameters.BulkJunctionBotGradingCoefficient *
                     (4e-4 * (Parameters.Temperature - Constants.ReferenceTemperature) - gmanew));
-            Properties.Cbd *= capfact;
-            Properties.Cbs *= capfact;
+                Properties.TempCbd *= capfact;
+                Properties.TempCbs *= capfact;
             Properties.TempCj *= capfact;
             capfact = (1 + ModelParameters.BulkJunctionSideGradingCoefficient *
                     (4e-4 * (Parameters.Temperature - Constants.ReferenceTemperature) - gmanew));

--- a/SpiceSharp/Components/Switches/Frequency.cs
+++ b/SpiceSharp/Components/Switches/Frequency.cs
@@ -34,13 +34,13 @@ namespace SpiceSharp.Components.Switches
             get
             {
                 double gNow = CurrentState ? ModelTemperature.OnConductance : ModelTemperature.OffConductance;
-                return ComplexVoltage * gNow;
+                return ComplexVoltage * gNow * Parameters.ParallelMultiplier;
             }
         }
 
         /// <include file='../Common/docs.xml' path='docs/members[@name="Frequency"]/Power/*'/>
         [ParameterName("p"), ParameterInfo("The complex power")]
-        public Complex ComplexPower => ComplexPower * Complex.Conjugate(ComplexCurrent);
+        public Complex ComplexPower => ComplexVoltage * Complex.Conjugate(ComplexCurrent);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Frequency"/> class.

--- a/SpiceSharp/Components/Voltagesources/VSRC/Frequency.cs
+++ b/SpiceSharp/Components/Voltagesources/VSRC/Frequency.cs
@@ -34,7 +34,7 @@ namespace SpiceSharp.Components.VoltageSources
 
         /// <include file='./Components/Common/docs.xml' path='docs/members[@name="frequency"]/Power/*'/>
         [ParameterName("p"), ParameterName("p_c"), ParameterInfo("Complex power")]
-        public Complex ComplexPower => -Voltage * Complex.Conjugate(Branch.Value);
+        public Complex ComplexPower => -ComplexVoltage * Complex.Conjugate(Branch.Value);
 
         /// <inheritdoc/>
         public new IVariable<Complex> Branch { get; }

--- a/SpiceSharp/Entities/ConcurrentEntityCollection.cs
+++ b/SpiceSharp/Entities/ConcurrentEntityCollection.cs
@@ -299,11 +299,20 @@ namespace SpiceSharp.Entities
             array.ThrowIfNull(nameof(array));
             if (arrayIndex < 0)
                 throw new ArgumentOutOfRangeException(nameof(arrayIndex));
-            if (array.Length < arrayIndex + Count)
-                throw new ArgumentException(Properties.Resources.NotEnoughElements);
 
-            foreach (var item in _entities.Values)
-                array[arrayIndex++] = item;
+            _lock.EnterReadLock();
+            try
+            {
+                if (arrayIndex > array.Length || array.Length - arrayIndex < _entities.Count)
+                    throw new ArgumentException(Properties.Resources.NotEnoughElements);
+
+                foreach (var item in _entities.Values)
+                    array[arrayIndex++] = item;
+            }
+            finally
+            {
+                _lock.ExitReadLock();
+            }
         }
 
         /// <summary>
@@ -320,7 +329,17 @@ namespace SpiceSharp.Entities
         public IEntityCollection Clone()
         {
             var clone = new ConcurrentEntityCollection(_entities.Comparer);
-            foreach (var pair in _entities.Values)
+            IEntity[] entities;
+            _lock.EnterReadLock();
+            try
+            {
+                entities = [.. _entities.Values];
+            }
+            finally
+            {
+                _lock.ExitReadLock();
+            }
+            foreach (var pair in entities)
                 clone.Add(pair.Clone());
             return clone;
         }

--- a/SpiceSharp/Entities/ConcurrentEntityCollection.cs
+++ b/SpiceSharp/Entities/ConcurrentEntityCollection.cs
@@ -135,28 +135,20 @@ namespace SpiceSharp.Entities
         public bool Remove(string name)
         {
             name.ThrowIfNull(nameof(name));
-            _lock.EnterUpgradeableReadLock();
+            IEntity entity = null;
+            bool success;
+            _lock.EnterWriteLock();
             try
             {
-                if (!_entities.TryGetValue(name, out var entity))
-                    return false;
-
-                _lock.EnterWriteLock();
-                try
-                {
-                    _entities.Remove(name);
-                    OnEntityRemoved(new EntityEventArgs(entity));
-                    return true;
-                }
-                finally
-                {
-                    _lock.ExitWriteLock();
-                }
+                success = _entities.TryGetValue(name, out entity) && _entities.Remove(name);
             }
             finally
             {
-                _lock.ExitUpgradeableReadLock();
+                _lock.ExitWriteLock();
             }
+            if (success)
+                OnEntityRemoved(new EntityEventArgs(entity));
+            return success;
         }
 
         /// <summary>

--- a/SpiceSharp/General/TypeDictionary/InheritedTypeDictionary.cs
+++ b/SpiceSharp/General/TypeDictionary/InheritedTypeDictionary.cs
@@ -84,7 +84,14 @@ namespace SpiceSharp.General
                     return false;
                 _values.Remove(value);
                 foreach (var type in InheritanceCache.Get(key).Union(InterfaceCache.Get(key)))
-                    _dictionary[type].Remove(value);
+                {
+                    if (_dictionary.TryGetValue(type, out var inheritedValues))
+                    {
+                        inheritedValues.Remove(value);
+                        if (inheritedValues.IsEmpty)
+                            _dictionary.Remove(type);
+                    }
+                }
                 _dictionary.Remove(key);
                 return true;
             }

--- a/SpiceSharp/General/TypeDictionary/InheritedTypeSet.cs
+++ b/SpiceSharp/General/TypeDictionary/InheritedTypeSet.cs
@@ -75,24 +75,20 @@ namespace SpiceSharp.General
         /// <inheritdoc/>
         public TResult GetValue<TResult>() where TResult : V
         {
-            try
+            if (!_dictionary.TryGetValue(typeof(TResult), out V result))
             {
-                if (!_dictionary.TryGetValue(typeof(TResult), out V result))
+                var args = new TypeNotFoundEventArgs<V>(typeof(TResult));
+                TypeNotFound?.Invoke(this, args);
+                if (args.Value is TResult newResult)
                 {
-                    var args = new TypeNotFoundEventArgs<V>(typeof(TResult));
-                    TypeNotFound?.Invoke(this, args);
-                    if (args.Value is TResult newResult)
-                    {
-                        Add(newResult);
-                        return newResult;
-                    }
+                    Add(newResult);
+                    return newResult;
                 }
-                return (TResult)result;
+                throw new TypeNotFoundException(
+                    typeof(TResult),
+                    Properties.Resources.TypeDictionary_TypeNotFound.FormatString(typeof(TResult).FullName));
             }
-            catch (KeyNotFoundException ex)
-            {
-                throw new TypeNotFoundException(Properties.Resources.TypeDictionary_TypeNotFound.FormatString(typeof(TResult).FullName), ex);
-            }
+            return (TResult)result;
         }
 
         /// <summary>

--- a/SpiceSharp/General/TypeDictionary/InterfaceTypeDictionary.cs
+++ b/SpiceSharp/General/TypeDictionary/InterfaceTypeDictionary.cs
@@ -88,7 +88,14 @@ namespace SpiceSharp.General
                 if (!existing.Equals(value))
                     return false;
                 foreach (var type in InterfaceCache.Get(key))
-                    _interfaces[type].Remove(value);
+                {
+                    if (_interfaces.TryGetValue(type, out var interfaceValues))
+                    {
+                        interfaceValues.Remove(value);
+                        if (interfaceValues.IsEmpty)
+                            _interfaces.Remove(type);
+                    }
+                }
                 _dictionary.Remove(key);
                 return true;
             }

--- a/SpiceSharp/General/TypeDictionary/InterfaceTypeSet.cs
+++ b/SpiceSharp/General/TypeDictionary/InterfaceTypeSet.cs
@@ -75,24 +75,20 @@ namespace SpiceSharp.General
         /// <inheritdoc/>
         public TResult GetValue<TResult>() where TResult : V
         {
-            try
+            if (!_dictionary.TryGetValue(typeof(TResult), out V result))
             {
-                if (!_dictionary.TryGetValue(typeof(TResult), out V result))
+                var args = new TypeNotFoundEventArgs<V>(typeof(TResult));
+                TypeNotFound?.Invoke(this, args);
+                if (args.Value is TResult newResult)
                 {
-                    var args = new TypeNotFoundEventArgs<V>(typeof(TResult));
-                    TypeNotFound?.Invoke(this, args);
-                    if (args.Value is TResult newResult)
-                    {
-                        Add(newResult);
-                        return newResult;
-                    }
+                    Add(newResult);
+                    return newResult;
                 }
-                return (TResult)result;
+                throw new TypeNotFoundException(
+                    typeof(TResult),
+                    Properties.Resources.TypeDictionary_TypeNotFound.FormatString(typeof(TResult).FullName));
             }
-            catch (KeyNotFoundException ex)
-            {
-                throw new TypeNotFoundException(Properties.Resources.TypeDictionary_TypeNotFound.FormatString(typeof(TResult).FullName), ex);
-            }
+            return (TResult)result;
         }
 
         /// <summary>

--- a/SpiceSharp/General/TypeDictionary/TypeValues.cs
+++ b/SpiceSharp/General/TypeDictionary/TypeValues.cs
@@ -37,7 +37,7 @@ namespace SpiceSharp.General
         /// <value>
         ///   <c>true</c> if this instance is ambiguous; otherwise, <c>false</c>.
         /// </value>
-        public bool IsAmbiguous => _first.IsIndirect && _first.Next != null;
+        public bool IsAmbiguous => _first != null && _first.IsIndirect && _first.Next != null;
 
         /// <summary>
         /// Gets a value indicating whether this instance is empty.
@@ -142,7 +142,9 @@ namespace SpiceSharp.General
         /// <param name="value">The value.</param>
         public bool Remove(T value)
         {
-            if (_first.Value.Equals(value))
+            if (_first == null)
+                return false;
+            if (EqualityComparer<T>.Default.Equals(_first.Value, value))
             {
                 _first = _first.Next;
                 Count--;
@@ -154,7 +156,7 @@ namespace SpiceSharp.General
                 var elt = _first.Next;
                 while (elt != null)
                 {
-                    if (elt.Value.Equals(value))
+                    if (EqualityComparer<T>.Default.Equals(elt.Value, value))
                     {
                         previous.Next = elt.Next;
                         Count--;

--- a/SpiceSharp/General/Utility.cs
+++ b/SpiceSharp/General/Utility.cs
@@ -141,7 +141,7 @@ namespace SpiceSharp
         /// <exception cref="ArgumentOutOfRangeException">Thrown if the value is not greater than <paramref name="limit"/>.</exception>
         public static double GreaterThan(this double value, string name, double limit)
         {
-            if (value <= limit)
+            if (double.IsNaN(value) || value <= limit)
                 throw new ArgumentOutOfRangeException(name, value, Properties.Resources.Parameters_NotGreater.FormatString(limit));
             return value;
         }
@@ -156,7 +156,7 @@ namespace SpiceSharp
         /// <exception cref="ArgumentOutOfRangeException">Thrown if the value is not less than <paramref name="limit"/>.</exception>
         public static double LessThan(this double value, string name, double limit)
         {
-            if (value >= limit)
+            if (double.IsNaN(value) || value >= limit)
                 throw new ArgumentOutOfRangeException(name, value, Properties.Resources.Parameters_NotLess.FormatString(limit));
             return value;
         }
@@ -171,7 +171,7 @@ namespace SpiceSharp
         /// <exception cref="ArgumentOutOfRangeException">Thrown if the value is not greater than or equal to <paramref name="limit"/>.</exception>
         public static double GreaterThanOrEquals(this double value, string name, double limit)
         {
-            if (value < limit)
+            if (double.IsNaN(value) || value < limit)
                 throw new ArgumentOutOfRangeException(name, value, Properties.Resources.Parameters_NotGreaterOrEqual.FormatString(limit));
             return value;
         }
@@ -186,7 +186,7 @@ namespace SpiceSharp
         /// <exception cref="ArgumentOutOfRangeException">Thrown if the value is not less than or equal to the specified limit.</exception>
         public static double LessThanOrEquals(this double value, string name, double limit)
         {
-            if (value > limit)
+            if (double.IsNaN(value) || value > limit)
                 throw new ArgumentOutOfRangeException(name, value, Properties.Resources.Parameters_NotLessOrEqual.FormatString(limit));
             return value;
         }

--- a/SpiceSharp/Simulations/Base/Reference.cs
+++ b/SpiceSharp/Simulations/Base/Reference.cs
@@ -20,18 +20,19 @@ namespace SpiceSharp.Simulations.Base
         /// Gets the path of the node.
         /// </summary>
         public IReadOnlyList<string> Path { get; }
+        private IReadOnlyList<string> SafePath => Path ?? Array.Empty<string>();
 
         /// <summary>
         /// Gets the length of the path.
         /// </summary>
-        public int Length => Path?.Count ?? 0;
+        public int Length => SafePath.Count;
 
         /// <summary>
         /// Gets an element of the hierarchical reference at the specified index.
         /// </summary>
         /// <param name="index">The index.</param>
         /// <returns>Returns the path item at the specified index.</returns>
-        public string this[int index] => Path[index];
+        public string this[int index] => SafePath[index];
 
         /// <summary>
         /// Creates a new <see cref="Reference"/>.
@@ -58,8 +59,9 @@ namespace SpiceSharp.Simulations.Base
         public override readonly int GetHashCode()
         {
             int hash = 0;
-            for (int i = 0; i < Path.Count; i++)
-                hash = (hash * 1021) ^ (Path[i]?.GetHashCode() ?? 0);
+            var path = SafePath;
+            for (int i = 0; i < path.Count; i++)
+                hash = (hash * 1021) ^ (path[i]?.GetHashCode() ?? 0);
             return hash;
         }
 
@@ -77,15 +79,17 @@ namespace SpiceSharp.Simulations.Base
         /// <returns>Returns <c>true</c> if both are equal; otherwise, <c>false</c>.</returns>
         public bool Equals(Reference other)
         {
-            if (Path.Count != other.Path.Count)
+            var path = SafePath;
+            var otherPath = other.SafePath;
+            if (path.Count != otherPath.Count)
                 return false;
-            for (int i = 0; i < Path.Count; i++)
+            for (int i = 0; i < path.Count; i++)
             {
-                if (Path[i] is null && other.Path[i] is null)
+                if (path[i] is null && otherPath[i] is null)
                     continue;
-                if (Path[i] is null || other.Path[i] is null)
+                if (path[i] is null || otherPath[i] is null)
                     return false;
-                if (!Path[i].Equals(other.Path[i]))
+                if (!path[i].Equals(otherPath[i]))
                     return false;
             }
             return true;
@@ -319,19 +323,19 @@ namespace SpiceSharp.Simulations.Base
         /// </summary>
         /// <returns>The string.</returns>
         public override string ToString()
-            => string.Join(Utility.Separator, Path);
+            => string.Join(Utility.Separator, SafePath);
 
         /// <summary>
         /// Gets an enumerator for the node reference.
         /// </summary>
         /// <returns>The enumerator.</returns>
-        IEnumerator<string> IEnumerable<string>.GetEnumerator() => Path.GetEnumerator();
+        IEnumerator<string> IEnumerable<string>.GetEnumerator() => SafePath.GetEnumerator();
 
         /// <summary>
         /// Gets an enumerator for the node reference.
         /// </summary>
         /// <returns>The enumerator.</returns>
-        IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)Path).GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)SafePath).GetEnumerator();
 
         /// <summary>
         /// Implicitly converts a string to a node reference.
@@ -345,13 +349,13 @@ namespace SpiceSharp.Simulations.Base
         /// </summary>
         /// <param name="path">The path.</param>
         public static implicit operator Reference(string[] path)
-            => new(path.ToArray());
+            => new(path);
 
         /// <summary>
         /// Implicitly converts a list of strings to a node reference.
         /// </summary>
         /// <param name="path">The path.</param>
         public static implicit operator Reference(List<string> path)
-            => new(path.ToArray());
+            => new(path?.ToArray());
     }
 }

--- a/SpiceSharp/Simulations/Exports/ComplexVoltageExport.cs
+++ b/SpiceSharp/Simulations/Exports/ComplexVoltageExport.cs
@@ -82,7 +82,7 @@ namespace SpiceSharp.Simulations
             else
             {
                 if (Reference.TryGetVariable<Complex, IComplexSimulationState>(simulation, out var negVariable))
-                    return () => negVariable.Value;
+                    return () => -negVariable.Value;
             }
             return null;
         }

--- a/SpiceSharp/Simulations/Exports/RealVoltageExport.cs
+++ b/SpiceSharp/Simulations/Exports/RealVoltageExport.cs
@@ -57,7 +57,7 @@ namespace SpiceSharp.Simulations
             else
             {
                 if (Reference.TryGetVariable<double, IBiasingSimulationState>(simulation, out var negVariable))
-                    return () => negVariable.Value;
+                    return () => -negVariable.Value;
             }
             return null;
         }

--- a/SpiceSharp/Simulations/Implementations/DC/ParameterSweep.cs
+++ b/SpiceSharp/Simulations/Implementations/DC/ParameterSweep.cs
@@ -107,6 +107,8 @@ namespace SpiceSharp.Simulations
                 if (setter != null)
                     break;
             }
+            if (setter == null)
+                throw new ArgumentException(Properties.Resources.Simulations_PropertyNotfound.FormatString(Name, Property));
 
             // Enumerate the points
             foreach (double pt in Points)

--- a/SpiceSharp/Simulations/Implementations/Time/IntegrationMethods/FixedEuler/FixedEuler.cs
+++ b/SpiceSharp/Simulations/Implementations/Time/IntegrationMethods/FixedEuler/FixedEuler.cs
@@ -23,12 +23,7 @@ namespace SpiceSharp.Simulations.IntegrationMethods
         public double Step
         {
             get => _step;
-            set
-            {
-                if (value <= 0.0)
-                    throw new ArgumentException(Properties.Resources.Simulations_Time_TimestepInvalid);
-                _step = value;
-            }
+            set => _step = value.Finite(nameof(Step)).GreaterThan(nameof(Step), 0.0);
         }
         private double _step;
 
@@ -39,6 +34,10 @@ namespace SpiceSharp.Simulations.IntegrationMethods
         /// <returns>
         /// The integration method.
         /// </returns>
-        public override IIntegrationMethod Create(IBiasingSimulationState state) => new Instance(this);
+        public override IIntegrationMethod Create(IBiasingSimulationState state)
+        {
+            _step.Finite(nameof(Step)).GreaterThan(nameof(Step), 0.0);
+            return new Instance(this);
+        }
     }
 }

--- a/SpiceSharp/Simulations/Implementations/Time/IntegrationMethods/FixedTrapezoidal/FixedTrapezoidal.cs
+++ b/SpiceSharp/Simulations/Implementations/Time/IntegrationMethods/FixedTrapezoidal/FixedTrapezoidal.cs
@@ -38,7 +38,17 @@ namespace SpiceSharp.Simulations.IntegrationMethods
         /// The xmu constant.
         /// </value>
         [ParameterName("xmu"), ParameterInfo("The xmu parameter.")]
-        public double Xmu { get; set; } = 0.5;
+        public double Xmu
+        {
+            get => _xmu;
+            set
+            {
+                if (double.IsNaN(value))
+                    throw new ArgumentOutOfRangeException(nameof(Xmu), value, Properties.Resources.Parameters_NotGreaterOrEqual.FormatString(0.0));
+                _xmu = value.GreaterThanOrEquals(nameof(Xmu), 0.0).LessThan(nameof(Xmu), 1.0);
+            }
+        }
+        private double _xmu = 0.5;
 
         /// <summary>
         /// Creates an instance of the integration method.

--- a/SpiceSharp/Simulations/Implementations/Time/IntegrationMethods/FixedTrapezoidal/FixedTrapezoidal.cs
+++ b/SpiceSharp/Simulations/Implementations/Time/IntegrationMethods/FixedTrapezoidal/FixedTrapezoidal.cs
@@ -22,12 +22,7 @@ namespace SpiceSharp.Simulations.IntegrationMethods
         public double Step
         {
             get => _step;
-            set
-            {
-                if (value <= 0)
-                    throw new ArgumentException(Properties.Resources.Simulations_Time_TimestepInvalid);
-                _step = value;
-            }
+            set => _step = value.Finite(nameof(Step)).GreaterThan(nameof(Step), 0.0);
         }
         private double _step;
 
@@ -57,6 +52,10 @@ namespace SpiceSharp.Simulations.IntegrationMethods
         /// <returns>
         /// The integration method.
         /// </returns>
-        public override IIntegrationMethod Create(IBiasingSimulationState state) => new Instance(this);
+        public override IIntegrationMethod Create(IBiasingSimulationState state)
+        {
+            _step.Finite(nameof(Step)).GreaterThan(nameof(Step), 0.0);
+            return new Instance(this);
+        }
     }
 }

--- a/SpiceSharp/Simulations/Implementations/Time/IntegrationMethods/Spice/Trapezoidal/Trapezoidal.cs
+++ b/SpiceSharp/Simulations/Implementations/Time/IntegrationMethods/Spice/Trapezoidal/Trapezoidal.cs
@@ -1,4 +1,5 @@
 ﻿using SpiceSharp.Attributes;
+using System;
 
 namespace SpiceSharp.Simulations.IntegrationMethods
 {
@@ -17,7 +18,17 @@ namespace SpiceSharp.Simulations.IntegrationMethods
         /// The xmu constant.
         /// </value>
         [ParameterName("xmu"), ParameterInfo("The xmu parameter.")]
-        public double Xmu { get; set; } = 0.5;
+        public double Xmu
+        {
+            get => _xmu;
+            set
+            {
+                if (double.IsNaN(value))
+                    throw new ArgumentOutOfRangeException(nameof(Xmu), value, Properties.Resources.Parameters_NotGreaterOrEqual.FormatString(0.0));
+                _xmu = value.GreaterThanOrEquals(nameof(Xmu), 0.0).LessThan(nameof(Xmu), 1.0);
+            }
+        }
+        private double _xmu = 0.5;
 
         /// <summary>
         /// Creates an instance of the integration method for an associated <see cref="IBiasingSimulationState" />.

--- a/SpiceSharp/Simulations/Implementations/Time/IntegrationMethods/VariableTimestepConfiguration.cs
+++ b/SpiceSharp/Simulations/Implementations/Time/IntegrationMethods/VariableTimestepConfiguration.cs
@@ -28,9 +28,7 @@ namespace SpiceSharp.Simulations.IntegrationMethods
             }
             set
             {
-                if (value < 0.0)
-                    throw new ArgumentException(Properties.Resources.Simulations_Time_TimestepInvalid);
-                _maxStep = value;
+                _maxStep = value.Finite(nameof(MaxStep)).GreaterThanOrEquals(nameof(MaxStep), 0.0);
             }
         }
         private double _maxStep = 0.0;
@@ -54,9 +52,7 @@ namespace SpiceSharp.Simulations.IntegrationMethods
             }
             set
             {
-                if (value < 0.0)
-                    throw new ArgumentException(Properties.Resources.Simulations_Time_TimestepInvalid);
-                _minStep = value;
+                _minStep = value.Finite(nameof(MinStep)).GreaterThanOrEquals(nameof(MinStep), 0.0);
             }
         }
         private double _minStep = 0.0;
@@ -74,9 +70,7 @@ namespace SpiceSharp.Simulations.IntegrationMethods
             get => _maxExpansion;
             set
             {
-                if (value < 1)
-                    throw new ArgumentException(Properties.Resources.Simulations_Time_MaximumExpansionTooSmall);
-                _maxExpansion = value;
+                _maxExpansion = value.Finite(nameof(MaximumExpansion)).GreaterThanOrEquals(nameof(MaximumExpansion), 1.0);
             }
         }
         private double _maxExpansion = 2.0;

--- a/SpiceSharp/Simulations/Simulation.cs
+++ b/SpiceSharp/Simulations/Simulation.cs
@@ -139,99 +139,123 @@ namespace SpiceSharp.Simulations
                 throw new ArgumentException(Properties.Resources.Simulations_CannotRunMultiple);
             _lastRun++;
             CurrentRun = _lastRun;
+            bool setupStarted = false;
+            bool cleanupStarted = false;
 
-            entities.ThrowIfNull(nameof(entities));
-
-            // Yield before setup - this is here for easier migration from Spice# 3.1.x
-            if ((mask & BeforeSetup) != 0)
-                yield return BeforeSetup;
-
-            // Setup the simulation
-            Statistics.SetupTime.Start();
-            try
+            void Cleanup()
             {
-                Status = SimulationStatus.Setup;
-                Setup(entities);
-            }
-            finally
-            {
-                Statistics.SetupTime.Stop();
-            }
-
-            // Yield after setup
-            if ((mask & AfterSetup) != 0)
-                yield return AfterSetup;
-
-            // Yield before validation - this is here for easier migration from Spice# 3.1.x
-            if ((mask & BeforeValidation) != 0)
-                yield return BeforeValidation;
-
-            // Validate the input
-            Statistics.ValidationTime.Start();
-            try
-            {
-                Status = SimulationStatus.Validation;
-                Validate(entities);
-            }
-            finally
-            {
-                Statistics.ValidationTime.Stop();
-            }
-
-            // Yield after validation
-            if ((mask & AfterValidation) != 0)
-                yield return AfterValidation;
-
-            // Execute the simulation
-            Status = SimulationStatus.Running;
-            do
-            {
-                Repeat = false;
-
-                // Before execution
-                if ((mask & BeforeExecute) != 0)
-                    yield return BeforeExecute;
-
-                // Execute simulation
-                Statistics.ExecutionTime.Start();
+                if (cleanupStarted)
+                    return;
+                cleanupStarted = true;
                 try
                 {
-                    foreach (int exportType in Execute(mask))
-                        yield return exportType;
+                    if (setupStarted)
+                    {
+                        Statistics.FinishTime.Start();
+                        try
+                        {
+                            Status = SimulationStatus.Unsetup;
+                            Finish();
+                        }
+                        finally
+                        {
+                            Statistics.FinishTime.Stop();
+                        }
+                    }
                 }
                 finally
                 {
-                    Statistics.ExecutionTime.Stop();
+                    CurrentRun = -1;
+                    Status = SimulationStatus.None;
                 }
+            }
 
-                // Reset                
-                if ((mask & AfterExecute) != 0)
-                    yield return AfterExecute;
-
-                // We're going to repeat the simulation, change the event arguments
-            } while (Repeat);
-
-            // Yield before cleanup
-            if ((mask & BeforeUnsetup) != 0)
-                yield return BeforeUnsetup;
-
-            // Clean up the circuit
-            Statistics.FinishTime.Start();
             try
             {
-                Status = SimulationStatus.Unsetup;
-                Finish();
+                entities.ThrowIfNull(nameof(entities));
+
+                // Yield before setup - this is here for easier migration from Spice# 3.1.x
+                if ((mask & BeforeSetup) != 0)
+                    yield return BeforeSetup;
+
+                // Setup the simulation
+                Statistics.SetupTime.Start();
+                try
+                {
+                    setupStarted = true;
+                    Status = SimulationStatus.Setup;
+                    Setup(entities);
+                }
+                finally
+                {
+                    Statistics.SetupTime.Stop();
+                }
+
+                // Yield after setup
+                if ((mask & AfterSetup) != 0)
+                    yield return AfterSetup;
+
+                // Yield before validation - this is here for easier migration from Spice# 3.1.x
+                if ((mask & BeforeValidation) != 0)
+                    yield return BeforeValidation;
+
+                // Validate the input
+                Statistics.ValidationTime.Start();
+                try
+                {
+                    Status = SimulationStatus.Validation;
+                    Validate(entities);
+                }
+                finally
+                {
+                    Statistics.ValidationTime.Stop();
+                }
+
+                // Yield after validation
+                if ((mask & AfterValidation) != 0)
+                    yield return AfterValidation;
+
+                // Execute the simulation
+                Status = SimulationStatus.Running;
+                do
+                {
+                    Repeat = false;
+
+                    // Before execution
+                    if ((mask & BeforeExecute) != 0)
+                        yield return BeforeExecute;
+
+                    // Execute simulation
+                    Statistics.ExecutionTime.Start();
+                    try
+                    {
+                        foreach (int exportType in Execute(mask))
+                            yield return exportType;
+                    }
+                    finally
+                    {
+                        Statistics.ExecutionTime.Stop();
+                    }
+
+                    // Reset
+                    if ((mask & AfterExecute) != 0)
+                        yield return AfterExecute;
+                } while (Repeat);
+
+                // Yield before cleanup
+                if ((mask & BeforeUnsetup) != 0)
+                    yield return BeforeUnsetup;
+
+                Cleanup();
+
+                // Yield after cleanup - this is here for easier migration from Spice# 3.1.x
+                if ((mask & AfterUnsetup) != 0)
+                    yield return AfterUnsetup;
             }
             finally
             {
-                CurrentRun = -1;
-                Statistics.FinishTime.Stop();
+                Cleanup();
             }
-            Status = SimulationStatus.None;
-
-            // Yield after cleanup - this is here for easier migration from Spice# 3.1.x
-            if ((mask & AfterUnsetup) != 0)
-                yield return AfterUnsetup;
         }
 
         /// <inheritdoc/>
@@ -241,55 +265,70 @@ namespace SpiceSharp.Simulations
                 throw new ArgumentException(Properties.Resources.Simulations_CannotRunMultiple);
             _lastRun++;
             CurrentRun = _lastRun;
+            bool cleanupStarted = false;
 
-            // Execute the simulation
-            Status = SimulationStatus.Running;
-            do
+            void Cleanup()
             {
-                Repeat = false;
-
-                // Yield before execute
-                if ((mask & BeforeExecute) != 0)
-                    yield return BeforeExecute;
-
-                // Execute simulation
-                Statistics.ExecutionTime.Start();
+                if (cleanupStarted)
+                    return;
+                cleanupStarted = true;
+                Statistics.FinishTime.Start();
                 try
                 {
-                    foreach (int exportType in Execute(mask))
-                        yield return exportType;
+                    Status = SimulationStatus.Unsetup;
+                    Finish();
                 }
                 finally
                 {
-                    Statistics.ExecutionTime.Stop();
+                    CurrentRun = -1;
+                    Status = SimulationStatus.None;
+                    Statistics.FinishTime.Stop();
                 }
+            }
 
-                // Yield after execute
-                if ((mask & AfterExecute) != 0)
-                    yield return AfterExecute;
-            } while (Repeat);
-
-            // Yield before cleanup
-            if ((mask & BeforeUnsetup) != 0)
-                yield return BeforeUnsetup;
-
-            // Clean up the circuit
-            Statistics.FinishTime.Start();
             try
             {
-                Status = SimulationStatus.Unsetup;
-                Finish();
+                // Execute the simulation
+                Status = SimulationStatus.Running;
+                do
+                {
+                    Repeat = false;
+
+                    // Yield before execute
+                    if ((mask & BeforeExecute) != 0)
+                        yield return BeforeExecute;
+
+                    // Execute simulation
+                    Statistics.ExecutionTime.Start();
+                    try
+                    {
+                        foreach (int exportType in Execute(mask))
+                            yield return exportType;
+                    }
+                    finally
+                    {
+                        Statistics.ExecutionTime.Stop();
+                    }
+
+                    // Yield after execute
+                    if ((mask & AfterExecute) != 0)
+                        yield return AfterExecute;
+                } while (Repeat);
+
+                // Yield before cleanup
+                if ((mask & BeforeUnsetup) != 0)
+                    yield return BeforeUnsetup;
+
+                Cleanup();
+
+                // Yield after cleanup - this is here for easier migration from Spice# 3.1.x
+                if ((mask & AfterUnsetup) != 0)
+                    yield return AfterUnsetup;
             }
             finally
             {
-                CurrentRun = -1;
-                Statistics.FinishTime.Stop();
+                Cleanup();
             }
-            Status = SimulationStatus.None;
-
-            // Yield after cleanup - this is here for easier migration from Spice# 3.1.x
-            if ((mask & AfterUnsetup) != 0)
-                yield return AfterUnsetup;
         }
 
         /// <summary>

--- a/SpiceSharp/Simulations/Variables/VariableMap.cs
+++ b/SpiceSharp/Simulations/Variables/VariableMap.cs
@@ -27,7 +27,7 @@ namespace SpiceSharp.Simulations
             get
             {
                 var result = _map.FirstOrDefault(p => p.Value == index);
-                if (result.Equals(default(IVariable)))
+                if (result.Equals(default(KeyValuePair<IVariable, int>)))
                     throw new ArgumentException(Properties.Resources.VariableNotFound.FormatString(index));
                 return result.Key;
             }
@@ -56,6 +56,8 @@ namespace SpiceSharp.Simulations
         {
             variable.ThrowIfNull(nameof(variable));
             index.GreaterThan(nameof(index), 0);
+            if (_map.ContainsValue(index))
+                throw new ArgumentException(Properties.Resources.VariableMap_KeyExists.FormatString(index), nameof(index));
             try
             {
                 _map.Add(variable, index);

--- a/SpiceSharpTest/Algebra/DenseMatrixTests.cs
+++ b/SpiceSharpTest/Algebra/DenseMatrixTests.cs
@@ -22,6 +22,16 @@ namespace SpiceSharpTest.Algebra
         }
 
         [Test]
+        public void When_DefaultIsAssignedOutsideMatrix_Expect_NoExpansion()
+        {
+            var matrix = new DenseMatrix<double>();
+
+            Assert.DoesNotThrow(() => matrix[10, 10] = 0.0);
+            Assert.That(matrix.Size, Is.Zero);
+            Assert.That(matrix[10, 10], Is.Zero);
+        }
+
+        [Test]
         public void When_SwappingRows_Expect_Reference()
         {
             var n = new DenseMatrix<double>();

--- a/SpiceSharpTest/Circuits/ConcurrentEntityCollectionTests.cs
+++ b/SpiceSharpTest/Circuits/ConcurrentEntityCollectionTests.cs
@@ -1,0 +1,30 @@
+using NUnit.Framework;
+using SpiceSharp.Components;
+using SpiceSharp.Entities;
+using System.Collections.Generic;
+
+namespace SpiceSharpTest.Circuits
+{
+    [TestFixture]
+    public class ConcurrentEntityCollectionTests
+    {
+        [Test]
+        public void When_CopyingAndCloning_Expect_AllEntities()
+        {
+            var collection = new ConcurrentEntityCollection
+            {
+                new Resistor("R1", "in", "0", 1.0),
+                new Resistor("R2", "out", "0", 2.0)
+            };
+            var entities = new IEntity[2];
+
+            ((ICollection<IEntity>)collection).CopyTo(entities, 0);
+            var clone = collection.Clone();
+
+            Assert.That(entities, Has.None.Null);
+            Assert.That(clone.Count, Is.EqualTo(2));
+            Assert.That(clone.Contains("R1"), Is.True);
+            Assert.That(clone.Contains("R2"), Is.True);
+        }
+    }
+}

--- a/SpiceSharpTest/Circuits/ConcurrentEntityCollectionTests.cs
+++ b/SpiceSharpTest/Circuits/ConcurrentEntityCollectionTests.cs
@@ -26,5 +26,25 @@ namespace SpiceSharpTest.Circuits
             Assert.That(clone.Contains("R1"), Is.True);
             Assert.That(clone.Contains("R2"), Is.True);
         }
+
+        [Test]
+        public void When_RemovalHandlerReadsCollection_Expect_NoLockRecursion()
+        {
+            var collection = new ConcurrentEntityCollection
+            {
+                new Resistor("R1", "in", "0", 1.0)
+            };
+            var observedCount = -1;
+            var observedContains = true;
+            collection.EntityRemoved += (_, args) =>
+            {
+                observedCount = collection.Count;
+                observedContains = collection.Contains(args.Entity.Name);
+            };
+
+            Assert.That(collection.Remove("R1"), Is.True);
+            Assert.That(observedCount, Is.Zero);
+            Assert.That(observedContains, Is.False);
+        }
     }
 }

--- a/SpiceSharpTest/General/GeneratorTests.cs
+++ b/SpiceSharpTest/General/GeneratorTests.cs
@@ -67,6 +67,17 @@ namespace SpiceSharpTest.General
         }
 
         [Test]
+        public void When_RangeParametersAreNaN_Expect_Exception()
+        {
+            var parameters = new TestParameters();
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => parameters.GreaterThan1 = double.NaN);
+            Assert.Throws<ArgumentOutOfRangeException>(() => parameters.LessThan1 = double.NaN);
+            Assert.Throws<ArgumentOutOfRangeException>(() => parameters.GreaterThanOrEquals1 = double.NaN);
+            Assert.Throws<ArgumentOutOfRangeException>(() => parameters.LessThanOrEquals1 = double.NaN);
+        }
+
+        [Test]
         public void When_LowerLimit_Expect_Reference()
         {
             var p = new TestParameters();

--- a/SpiceSharpTest/General/TypeSetTests.cs
+++ b/SpiceSharpTest/General/TypeSetTests.cs
@@ -8,6 +8,7 @@ namespace SpiceSharpTest.General
     public class TypeSetTests
     {
         private interface IValue { }
+        private class Value : IValue { }
 
         [Test]
         public void When_InheritedTypeIsMissing_Expect_Exception()
@@ -25,6 +26,28 @@ namespace SpiceSharpTest.General
 
             var exception = Assert.Throws<TypeNotFoundException>(() => set.GetValue<IValue>());
             Assert.That(exception.Type, Is.EqualTo(typeof(IValue)));
+        }
+
+        [Test]
+        public void When_LastInheritedTypeIsRemoved_Expect_InterfaceLookupIsMissing()
+        {
+            var value = new Value();
+            var set = new InheritedTypeSet<object> { value };
+
+            Assert.That(set.Remove(value), Is.True);
+            Assert.That(set.ContainsType<IValue>(), Is.False);
+            Assert.That(set.TryGetValue<IValue>(out _), Is.False);
+        }
+
+        [Test]
+        public void When_LastInterfaceTypeIsRemoved_Expect_InterfaceLookupIsMissing()
+        {
+            var value = new Value();
+            var set = new InterfaceTypeSet<object> { value };
+
+            Assert.That(set.Remove(value), Is.True);
+            Assert.That(set.ContainsType<IValue>(), Is.False);
+            Assert.That(set.TryGetValue<IValue>(out _), Is.False);
         }
     }
 }

--- a/SpiceSharpTest/General/TypeSetTests.cs
+++ b/SpiceSharpTest/General/TypeSetTests.cs
@@ -1,0 +1,30 @@
+using NUnit.Framework;
+using SpiceSharp;
+using SpiceSharp.General;
+
+namespace SpiceSharpTest.General
+{
+    [TestFixture]
+    public class TypeSetTests
+    {
+        private interface IValue { }
+
+        [Test]
+        public void When_InheritedTypeIsMissing_Expect_Exception()
+        {
+            var set = new InheritedTypeSet<object>();
+
+            var exception = Assert.Throws<TypeNotFoundException>(() => set.GetValue<IValue>());
+            Assert.That(exception.Type, Is.EqualTo(typeof(IValue)));
+        }
+
+        [Test]
+        public void When_InterfaceTypeIsMissing_Expect_Exception()
+        {
+            var set = new InterfaceTypeSet<object>();
+
+            var exception = Assert.Throws<TypeNotFoundException>(() => set.GetValue<IValue>());
+            Assert.That(exception.Type, Is.EqualTo(typeof(IValue)));
+        }
+    }
+}

--- a/SpiceSharpTest/Models/ExportPropertyRegressionTests.cs
+++ b/SpiceSharpTest/Models/ExportPropertyRegressionTests.cs
@@ -1,0 +1,166 @@
+using NUnit.Framework;
+using SpiceSharp;
+using SpiceSharp.Components;
+using SpiceSharp.Simulations;
+using System;
+using System.Numerics;
+
+namespace SpiceSharpTest.Models
+{
+    [TestFixture]
+    public class ExportPropertyRegressionTests
+    {
+        private static void AssertComplex(Complex actual, Complex expected)
+        {
+            Assert.That(actual.Real, Is.EqualTo(expected.Real).Within(1e-12));
+            Assert.That(actual.Imaginary, Is.EqualTo(expected.Imaginary).Within(1e-12));
+        }
+
+        [Test]
+        public void When_ReferenceOnlyVoltageIsExported_Expect_NegatedValue()
+        {
+            var circuit = new Circuit(
+                new VoltageSource("V1", "in", "0", 2.0).SetParameter("ac", new[] { 2.0, 90.0 }),
+                new Resistor("R1", "in", "0", 1.0));
+
+            var op = new OP("op");
+            var real = new RealVoltageExport(op, default, "in");
+            foreach (var _ in op.Run(circuit, OP.ExportOperatingPoint))
+                Assert.That(real.Value, Is.EqualTo(-2.0).Within(1e-12));
+
+            var ac = new AC("ac", new LinearSweep(1.0, 1.0, 1));
+            var complex = new ComplexVoltageExport(ac, default, "in");
+            foreach (var _ in ac.Run(circuit, AC.ExportSmallSignal))
+                AssertComplex(complex.Value, new Complex(0.0, -2.0));
+        }
+
+        [Test]
+        public void When_CurrentSourceHasMultiplier_Expect_ScaledAcProperties()
+        {
+            var source = new CurrentSource("I1", "0", "out", 0.0)
+                .SetParameter("acmag", 1.0)
+                .SetParameter("m", 2.0);
+            var circuit = new Circuit(source, new Resistor("R1", "out", "0", 1.0));
+            var ac = new AC("ac", new LinearSweep(1.0, 1.0, 1));
+            var voltage = new ComplexPropertyExport(ac, "I1", "v");
+            var current = new ComplexPropertyExport(ac, "I1", "i");
+            var power = new ComplexPropertyExport(ac, "I1", "p");
+
+            foreach (var _ in ac.Run(circuit, AC.ExportSmallSignal))
+            {
+                AssertComplex(current.Value, new Complex(2.0, 0.0));
+                AssertComplex(power.Value, -voltage.Value * Complex.Conjugate(current.Value));
+            }
+        }
+
+        [Test]
+        public void When_ControlledSourcesHaveMultiplier_Expect_ScaledProperties()
+        {
+            var vccs = new VoltageControlledCurrentSource("G1", "0", "gout", "in", "0", 1.0)
+                .SetParameter("m", 2.0);
+            var cccs = new CurrentControlledCurrentSource("F1", "0", "fout", "V1", 1.0)
+                .SetParameter("m", 2.0);
+            var circuit = new Circuit(
+                new VoltageSource("V1", "in", "0", 1.0).SetParameter("acmag", 1.0),
+                new Resistor("Rin", "in", "0", 1.0),
+                vccs,
+                new Resistor("Rg", "gout", "0", 1.0),
+                cccs,
+                new Resistor("Rf", "fout", "0", 1.0));
+
+            var op = new OP("op");
+            var vccsCurrent = new RealPropertyExport(op, "G1", "i");
+            var cccsCurrent = new RealPropertyExport(op, "F1", "i");
+            foreach (var _ in op.Run(circuit, OP.ExportOperatingPoint))
+            {
+                Assert.That(Math.Abs(vccsCurrent.Value), Is.EqualTo(2.0).Within(1e-12));
+                Assert.That(Math.Abs(cccsCurrent.Value), Is.EqualTo(2.0).Within(1e-12));
+            }
+
+            var ac = new AC("ac", new LinearSweep(1.0, 1.0, 1));
+            var complexVccsCurrent = new ComplexPropertyExport(ac, "G1", "i");
+            var complexCccsCurrent = new ComplexPropertyExport(ac, "F1", "i");
+            foreach (var _ in ac.Run(circuit, AC.ExportSmallSignal))
+            {
+                Assert.That(complexVccsCurrent.Value.Magnitude, Is.EqualTo(2.0).Within(1e-12));
+                Assert.That(complexCccsCurrent.Value.Magnitude, Is.EqualTo(2.0).Within(1e-12));
+            }
+        }
+
+        [Test]
+        public void When_ReactiveAndIndependentComponentsExportPower_Expect_ComplexPowerIdentity()
+        {
+            var circuit = new Circuit(
+                new VoltageSource("V1", "in", "0", 0.0).SetParameter("ac", new[] { 1.0, 90.0 }),
+                new Inductor("L1", "in", "out", 1.0 / (2.0 * Math.PI)),
+                new Resistor("R1", "out", "0", 1.0));
+            var ac = new AC("ac", new LinearSweep(1.0, 1.0, 1));
+            var sourceVoltage = new ComplexPropertyExport(ac, "V1", "v");
+            var sourceCurrent = new ComplexPropertyExport(ac, "V1", "i");
+            var sourcePower = new ComplexPropertyExport(ac, "V1", "p");
+            var inductorVoltage = new ComplexPropertyExport(ac, "L1", "v");
+            var inductorCurrent = new ComplexPropertyExport(ac, "L1", "i");
+            var inductorPower = new ComplexPropertyExport(ac, "L1", "p");
+
+            foreach (var _ in ac.Run(circuit, AC.ExportSmallSignal))
+            {
+                AssertComplex(sourcePower.Value, -sourceVoltage.Value * Complex.Conjugate(sourceCurrent.Value));
+                AssertComplex(inductorPower.Value, -inductorVoltage.Value * Complex.Conjugate(inductorCurrent.Value));
+            }
+        }
+
+        [Test]
+        public void When_SwitchExportsAcProperties_Expect_ScaledCurrentAndPower()
+        {
+            var circuit = new Circuit(
+                new VoltageSource("Vctrl", "ctrl", "0", 1.0),
+                new VoltageSource("Vac", "supply", "0", 0.0).SetParameter("acmag", 1.0),
+                new Resistor("R1", "supply", "out", 1.0),
+                new VoltageSwitch("S1", "out", "0", "ctrl", "0", "SM").SetParameter("m", 2.0),
+                new VoltageSwitchModel("SM")
+                    .SetParameter("vt", 0.5)
+                    .SetParameter("ron", 1.0)
+                    .SetParameter("roff", 1e6));
+            var ac = new AC("ac", new LinearSweep(1.0, 1.0, 1));
+            var voltage = new ComplexPropertyExport(ac, "S1", "v");
+            var current = new ComplexPropertyExport(ac, "S1", "i");
+            var power = new ComplexPropertyExport(ac, "S1", "p");
+
+            foreach (var _ in ac.Run(circuit, AC.ExportSmallSignal))
+            {
+                AssertComplex(current.Value, voltage.Value * 2.0);
+                AssertComplex(power.Value, voltage.Value * Complex.Conjugate(current.Value));
+            }
+        }
+
+        [Test]
+        public void When_TransmissionLineExportsPower_Expect_PerPortValues()
+        {
+            var circuit = new Circuit(
+                new VoltageSource("V1", "in", "0", 1.0).SetParameter("acmag", 1.0),
+                new Resistor("Rsource", "in", "a", 100.0),
+                new LosslessTransmissionLine("T1", "a", "0", "b", "0", 50.0, 1e-3),
+                new Resistor("Rload", "b", "0", 25.0));
+
+            var op = new OP("op");
+            var voltage2 = new RealPropertyExport(op, "T1", "v2");
+            var current2 = new RealPropertyExport(op, "T1", "i2");
+            var power2 = new RealPropertyExport(op, "T1", "p2");
+            foreach (var _ in op.Run(circuit, OP.ExportOperatingPoint))
+                Assert.That(power2.Value, Is.EqualTo(-voltage2.Value * current2.Value).Within(1e-12));
+
+            var ac = new AC("ac", new LinearSweep(100.0, 100.0, 1));
+            var complexVoltage1 = new ComplexPropertyExport(ac, "T1", "v1");
+            var complexCurrent1 = new ComplexPropertyExport(ac, "T1", "i1");
+            var complexPower1 = new ComplexPropertyExport(ac, "T1", "p1");
+            var complexVoltage2 = new ComplexPropertyExport(ac, "T1", "v2");
+            var complexCurrent2 = new ComplexPropertyExport(ac, "T1", "i2");
+            var complexPower2 = new ComplexPropertyExport(ac, "T1", "p2");
+            foreach (var _ in ac.Run(circuit, AC.ExportSmallSignal))
+            {
+                AssertComplex(complexPower1.Value, -complexVoltage1.Value * Complex.Conjugate(complexCurrent1.Value));
+                AssertComplex(complexPower2.Value, -complexVoltage2.Value * Complex.Conjugate(complexCurrent2.Value));
+            }
+        }
+    }
+}

--- a/SpiceSharpTest/Models/Semiconductors/Mosfet/Level1/MOS1Tests.cs
+++ b/SpiceSharpTest/Models/Semiconductors/Mosfet/Level1/MOS1Tests.cs
@@ -558,5 +558,28 @@ namespace SpiceSharpTest.Models
             Compare(ac, ckt_ref, ckt_act, exports);
             DestroyExports(exports);
         }
+
+        [Test]
+        public void When_GateBulkOverlapCapacitanceChanges_Expect_CapacitorCurrent()
+        {
+            const double length = 1e-4;
+            const double gateBulkCapFactor = 1e-5;
+            var waveform = new Pulse(0.0, 1.0, 0.0, 1e-6, 1e-6, 1e-6, 4e-6);
+            var circuit = new Circuit(
+                new VoltageSource("Vmos", "gmos", "0", waveform),
+                CreateMOS1("M1", "0", "gmos", "0", "0", "MM").SetParameter("l", length),
+                CreateMOS1Model("MM", $"IS=0 VTO=10 KP=0 TOX=1 CGBO={gateBulkCapFactor}"),
+                new VoltageSource("Vcap", "gcap", "0", waveform.Clone()),
+                new Capacitor("C1", "gcap", "0", gateBulkCapFactor * length));
+            var transient = new Transient("tran", 1e-8, 0.9e-6);
+            var mosCurrent = new RealPropertyExport(transient, "Vmos", "i");
+            var capacitorCurrent = new RealPropertyExport(transient, "Vcap", "i");
+
+            foreach (var _ in transient.Run(circuit, Transient.ExportTransient))
+            {
+                if (transient.Time > 1e-8)
+                    Assert.That(mosCurrent.Value, Is.EqualTo(capacitorCurrent.Value).Within(1e-9));
+            }
+        }
     }
 }

--- a/SpiceSharpTest/Simulations/DCTests.cs
+++ b/SpiceSharpTest/Simulations/DCTests.cs
@@ -55,6 +55,20 @@ namespace SpiceSharpTest.Simulations
         }
 
         [Test]
+        public void When_DCSweepParameterIsMissing_Expect_Exception()
+        {
+            var circuit = new Circuit(new VoltageSource("V1", "in", "0", 0));
+            var dc = new DC("dc", [new ParameterSweep("V1", "missing", new LinearSweep(0, 1, 2))]);
+
+            Assert.Throws<ArgumentException>(() =>
+            {
+                foreach (var _ in dc.Run(circuit))
+                {
+                }
+            });
+        }
+
+        [Test]
         public void When_DiodeDCTwice_Expect_NoException()
         {
             /*

--- a/SpiceSharpTest/Simulations/OPTests.cs
+++ b/SpiceSharpTest/Simulations/OPTests.cs
@@ -2,6 +2,7 @@
 using SpiceSharp.Components;
 using SpiceSharp.Simulations;
 using SpiceSharp;
+using SpiceSharp.Validation;
 
 namespace SpiceSharpTest.Simulations
 {
@@ -37,6 +38,40 @@ namespace SpiceSharpTest.Simulations
                 BiasingSimulation.BeforeTemperature |
                 BiasingSimulation.AfterTemperature |
                 OP.ExportOperatingPoint));
+        }
+
+        [Test]
+        public void When_RunIsDisposedAfterSetup_Expect_SimulationCanRunAgain()
+        {
+            var circuit = new Circuit(
+                new VoltageSource("V1", "in", "0", 1.0),
+                new Resistor("R1", "in", "0", 1.0));
+            var simulation = new OP("op");
+
+            using (var enumerator = simulation.Run(circuit, Simulation.AfterSetup).GetEnumerator())
+            {
+                Assert.That(enumerator.MoveNext(), Is.True);
+                Assert.That(enumerator.Current, Is.EqualTo(Simulation.AfterSetup));
+            }
+
+            Assert.That(simulation.CurrentRun, Is.EqualTo(-1));
+            Assert.That(simulation.Status, Is.EqualTo(SimulationStatus.None));
+            Assert.DoesNotThrow(() => simulation.RunToEnd(circuit));
+        }
+
+        [Test]
+        public void When_RunValidationFails_Expect_SimulationCanRunAgain()
+        {
+            var invalidCircuit = new Circuit(new Resistor("R1", "a", "b", 1.0));
+            var validCircuit = new Circuit(
+                new VoltageSource("V1", "in", "0", 1.0),
+                new Resistor("R1", "in", "0", 1.0));
+            var simulation = new OP("op");
+
+            Assert.Throws<ValidationFailedException>(() => simulation.RunToEnd(invalidCircuit));
+            Assert.That(simulation.CurrentRun, Is.EqualTo(-1));
+            Assert.That(simulation.Status, Is.EqualTo(SimulationStatus.None));
+            Assert.DoesNotThrow(() => simulation.RunToEnd(validCircuit));
         }
     }
 }

--- a/SpiceSharpTest/Simulations/ReferenceTests.cs
+++ b/SpiceSharpTest/Simulations/ReferenceTests.cs
@@ -1,0 +1,27 @@
+using NUnit.Framework;
+using SpiceSharp.Simulations.Base;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SpiceSharpTest.Simulations
+{
+    [TestFixture]
+    public class ReferenceTests
+    {
+        [Test]
+        public void When_ReferenceIsDefault_Expect_EmptyValueBehavior()
+        {
+            Reference value = default;
+            Reference fromNullArray = (string[])null;
+            Reference fromNullList = (List<string>)null;
+
+            Assert.That(value.Length, Is.Zero);
+            Assert.That(value, Is.EqualTo(new Reference()));
+            Assert.That(value.GetHashCode(), Is.EqualTo(new Reference().GetHashCode()));
+            Assert.That(value.ToString(), Is.Empty);
+            Assert.That(value.ToArray(), Is.Empty);
+            Assert.That(fromNullArray, Is.EqualTo(value));
+            Assert.That(fromNullList, Is.EqualTo(value));
+        }
+    }
+}

--- a/SpiceSharpTest/Simulations/TrapezoidalParameterTests.cs
+++ b/SpiceSharpTest/Simulations/TrapezoidalParameterTests.cs
@@ -28,5 +28,31 @@ namespace SpiceSharpTest.Simulations
 
             Assert.Throws<ArgumentOutOfRangeException>(() => method.Xmu = value);
         }
+
+        [TestCase(double.NaN)]
+        [TestCase(double.PositiveInfinity)]
+        public void When_FixedStepIsNotFinite_Expect_Exception(double value)
+        {
+            Assert.That(() => new FixedEuler { Step = value }, Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => new FixedTrapezoidal { Step = value }, Throws.InstanceOf<ArgumentException>());
+        }
+
+        [Test]
+        public void When_FixedStepIsUnset_Expect_CreateException()
+        {
+            Assert.That(() => new FixedEuler().Create(null), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => new FixedTrapezoidal().Create(null), Throws.InstanceOf<ArgumentException>());
+        }
+
+        [TestCase(double.NaN)]
+        [TestCase(double.PositiveInfinity)]
+        public void When_VariableStepLimitsAreNotFinite_Expect_Exception(double value)
+        {
+            var method = new Trapezoidal();
+
+            Assert.That(() => method.MaxStep = value, Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => method.MinStep = value, Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => method.MaximumExpansion = value, Throws.InstanceOf<ArgumentException>());
+        }
     }
 }

--- a/SpiceSharpTest/Simulations/TrapezoidalParameterTests.cs
+++ b/SpiceSharpTest/Simulations/TrapezoidalParameterTests.cs
@@ -1,0 +1,32 @@
+using NUnit.Framework;
+using SpiceSharp.Simulations.IntegrationMethods;
+using System;
+
+namespace SpiceSharpTest.Simulations
+{
+    [TestFixture]
+    public class TrapezoidalParameterTests
+    {
+        [TestCase(-0.1)]
+        [TestCase(1.0)]
+        [TestCase(1.1)]
+        [TestCase(double.NaN)]
+        public void When_SpiceTrapezoidalXmuIsInvalid_Expect_Exception(double value)
+        {
+            var method = new Trapezoidal();
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => method.Xmu = value);
+        }
+
+        [TestCase(-0.1)]
+        [TestCase(1.0)]
+        [TestCase(1.1)]
+        [TestCase(double.NaN)]
+        public void When_FixedTrapezoidalXmuIsInvalid_Expect_Exception(double value)
+        {
+            var method = new FixedTrapezoidal();
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => method.Xmu = value);
+        }
+    }
+}

--- a/SpiceSharpTest/Simulations/VariableMapTests.cs
+++ b/SpiceSharpTest/Simulations/VariableMapTests.cs
@@ -1,0 +1,28 @@
+using NUnit.Framework;
+using SpiceSharp.Simulations;
+using System;
+
+namespace SpiceSharpTest.Simulations
+{
+    [TestFixture]
+    public class VariableMapTests
+    {
+        [Test]
+        public void When_IndexIsMissing_Expect_Exception()
+        {
+            var map = new VariableMap(new Variable("0", null));
+
+            Assert.Throws<ArgumentException>(() => _ = map[1]);
+        }
+
+        [Test]
+        public void When_IndexAlreadyMapped_Expect_Exception()
+        {
+            var map = new VariableMap(new Variable("0", null));
+            map.Add(new Variable("a", null), 1);
+
+            Assert.Throws<ArgumentException>(() => map.Add(new Variable("b", null), 1));
+            Assert.That(map[1].Name, Is.EqualTo("a"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR combines two commits that address correctness issues across simulation lifecycle management, integration-method validation, numerical models, component properties, collections, and algebra infrastructure.

The changes primarily:

- Prevent simulations from remaining locked after exceptions or early enumeration disposal.
- Correct component current, voltage, and complex-power properties.
- Reject invalid numerical parameters before they propagate into a simulation.
- Repair MOS transient charge and temperature calculations.
- Harden type dictionaries, entity collections, variable maps, and dense matrices.
- Add focused regression coverage for each corrected behavior.

No public API signatures were changed.

## Commit breakdown

### `c4ffc495` - Foundational validation and collection fixes

- Correct `DenseVector` length validation and prevent `length + 1` overflow.
- Make `ConcurrentEntityCollection.CopyTo` and `Clone` operate on consistent, locked snapshots.
- Return informative `TypeNotFoundException` instances from inherited and interface type sets.
- Throw a clear exception when a DC sweep references a missing parameter.
- Enforce the trapezoidal integration range `0 <= Xmu < 1` and reject `NaN`.
- Correct missing-index detection in `VariableMap`.
- Reject duplicate `VariableMap` indices without modifying the existing mapping.

### `14c7ca63` - Simulation, model, and export fixes

- Guarantee simulation cleanup after normal completion, exceptions, and early iterator disposal.
- Correct component property calculations and multiplier handling.
- Repair MOS transient charge and Level 2 temperature-capacitance calculations.
- Reject `NaN` and non-finite timestep parameters.
- Clean up stale inherited/interface type mappings after removal.
- Make the default `Reference` value behave as a valid empty reference.
- Prevent lock recursion in concurrent entity removal callbacks.
- Treat distant zero assignments to a dense matrix as no-ops.

## Simulation lifecycle and integration

- Ensure `Simulation.Run` and `Simulation.Rerun` always reset `CurrentRun` and `Status`.
- Run simulation cleanup when execution throws or the result enumerator is disposed early.
- Preserve the existing simulation action/yield ordering during normal execution.
- Require fixed Euler and fixed trapezoidal steps to be finite and greater than zero.
- Fail fast when a fixed-step method is created without configuring its required step.
- Require variable minimum/maximum steps and expansion factors to be finite.
- Reject `NaN` consistently in shared floating-point range validators.

## Component and numerical corrections

- Include `ParallelMultiplier` in CCCS and VCCS current properties for DC and AC analyses.
- Include `ParallelMultiplier` in independent current-source and switch AC properties.
- Fix the switch `ComplexPower` self-reference that caused infinite recursion.
- Use the complex source voltage when calculating voltage-source AC power.
- Apply complex conjugation when calculating inductor AC power.
- Calculate transmission-line port-two power from port-two voltage and current.
- Use complex per-port quantities and conjugated currents for transmission-line AC power.
- Initialize MOS gate-drain charge from `Cgd` rather than `Cgs`.
- Update MOS gate-bulk charge from the actual gate-bulk voltage change.
- Apply Level 2 MOS temperature scaling to `TempCbd` and `TempCbs`, matching Levels 1 and 3.

## Exports and references

- Correct the sign of reference-only voltage exports so `V(0,node)` returns `-V(node)`.
- Make `default(Reference)` safe for:
  - Equality
  - Hashing
  - String formatting
  - Indexing and enumeration
  - Null array and list conversions
- Correct multiplier-aware current and power exports so reported values match solver stamps.

## Collections and algebra

- Remove empty inherited/interface lookup buckets after deleting their last value.
- Make empty `TypeValues` ambiguity and removal operations null-safe.
- Invoke concurrent entity-removal callbacks after releasing the collection lock.
- Allow removal callbacks to inspect the collection without `LockRecursionException`.
- Make assigning a default value outside a `DenseMatrix` a no-op instead of throwing or expanding.
- Preserve existing non-default matrix expansion behavior.

## Tests

Added 34 regression test cases covering:

- Simulation reuse after disposal and validation failure.
- Complex power identities for sources, switches, inductors, and transmission lines.
- Multiplier-aware current properties.
- Reference-only voltage polarity.
- MOS gate-bulk transient charge.
- `NaN`, infinity, and unset timestep validation.
- Empty `Reference` behavior.
- Type-set removal and stale lookup cleanup.
- Concurrent removal callback reentrancy.
- Dense matrix default assignments.
- DC sweep, `VariableMap`, trapezoidal, and collection edge cases.
